### PR TITLE
Refactor URL Generator

### DIFF
--- a/InternetArchiveKit.xcodeproj/project.pbxproj
+++ b/InternetArchiveKit.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		961F1594224A003700D874EE /* InternetArchiveErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BAF7D5219BD518004B512D /* InternetArchiveErrors.swift */; };
 		9656DE4D21A4C5EB0016392A /* DateParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9656DE4C21A4C5EB0016392A /* DateParser.swift */; };
 		96665F7A21D1A46C00D23477 /* ModelField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96665F7921D1A46C00D23477 /* ModelField.swift */; };
+		9667924F22683635005005A6 /* InternetArchiveURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667924E22683635005005A6 /* InternetArchiveURLGenerator.swift */; };
 		9669B01C2197B76D00E7CE2A /* artists.json in Resources */ = {isa = PBXBuildFile; fileRef = 9669B01B2197B76D00E7CE2A /* artists.json */; };
 		9669B0242197B91200E7CE2A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9669B0232197B91200E7CE2A /* AppDelegate.swift */; };
 		9669B0262197B91200E7CE2A /* EtreeCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9669B0252197B91200E7CE2A /* EtreeCollectionViewController.swift */; };
@@ -37,6 +38,7 @@
 		968C8346219A7F1100B89646 /* ConcertDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968C8345219A7F1100B89646 /* ConcertDataSource.swift */; };
 		968C8348219A817800B89646 /* ConcertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968C8347219A817800B89646 /* ConcertViewController.swift */; };
 		968C834C219A987C00B89646 /* ModelFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968C834B219A987C00B89646 /* ModelFieldTests.swift */; };
+		968EBEAF2268CAE300AE593D /* InternetArchiveURLGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9667924E22683635005005A6 /* InternetArchiveURLGenerator.swift */; };
 		9694E66A219A6F3E00F6D26B /* ConcertsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9694E669219A6F3E00F6D26B /* ConcertsDataSource.swift */; };
 		96AC7279219C64F1007C7910 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC7278219C64F1007C7910 /* Debouncer.swift */; };
 		96AC727B219D2E6A007C7910 /* MusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC727A219D2E6A007C7910 /* MusicPlayer.swift */; };
@@ -46,7 +48,7 @@
 		96BAF7D6219BD518004B512D /* InternetArchiveErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BAF7D5219BD518004B512D /* InternetArchiveErrors.swift */; };
 		96BAF7D8219BD6FE004B512D /* Collection+InternetArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BAF7D7219BD6FE004B512D /* Collection+InternetArchive.swift */; };
 		96BAF7DA219BF148004B512D /* InternetArchiveKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96ECE0D821913AE100A0C8A6 /* InternetArchiveKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		96E54CEB2198054F000B9B75 /* APIControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E54CEA2198054F000B9B75 /* APIControllerTests.swift */; };
+		96E54CEB2198054F000B9B75 /* URLGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E54CEA2198054F000B9B75 /* URLGeneratorTests.swift */; };
 		96ECE0E221913AE200A0C8A6 /* InternetArchiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96ECE0D821913AE100A0C8A6 /* InternetArchiveKit.framework */; };
 		96ECE0E721913AE200A0C8A6 /* InternetArchiveKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96ECE0E621913AE200A0C8A6 /* InternetArchiveKitTests.swift */; };
 		96ECE0E921913AE200A0C8A6 /* InternetArchiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 96ECE0DB21913AE100A0C8A6 /* InternetArchiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -95,6 +97,7 @@
 		9614039122654AA4001B9FB7 /* ModelFieldTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFieldTypes.swift; sourceTree = "<group>"; };
 		9656DE4C21A4C5EB0016392A /* DateParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateParser.swift; sourceTree = "<group>"; };
 		96665F7921D1A46C00D23477 /* ModelField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelField.swift; sourceTree = "<group>"; };
+		9667924E22683635005005A6 /* InternetArchiveURLGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetArchiveURLGenerator.swift; sourceTree = "<group>"; };
 		9669B01B2197B76D00E7CE2A /* artists.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = artists.json; sourceTree = "<group>"; };
 		9669B0212197B91200E7CE2A /* InternetArchiveKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InternetArchiveKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9669B0232197B91200E7CE2A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -116,7 +119,7 @@
 		96BAF7D3219BD4F7004B512D /* InternetArchiveProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetArchiveProtocols.swift; sourceTree = "<group>"; };
 		96BAF7D5219BD518004B512D /* InternetArchiveErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetArchiveErrors.swift; sourceTree = "<group>"; };
 		96BAF7D7219BD6FE004B512D /* Collection+InternetArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+InternetArchive.swift"; sourceTree = "<group>"; };
-		96E54CEA2198054F000B9B75 /* APIControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIControllerTests.swift; sourceTree = "<group>"; };
+		96E54CEA2198054F000B9B75 /* URLGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLGeneratorTests.swift; sourceTree = "<group>"; };
 		96ECE0D821913AE100A0C8A6 /* InternetArchiveKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = InternetArchiveKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		96ECE0DB21913AE100A0C8A6 /* InternetArchiveKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InternetArchiveKit.h; sourceTree = "<group>"; };
 		96ECE0DC21913AE100A0C8A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -247,6 +250,7 @@
 			children = (
 				96ECE0F221913D1E00A0C8A6 /* Models */,
 				96ECE0F921929F8D00A0C8A6 /* InternetArchive.swift */,
+				9667924E22683635005005A6 /* InternetArchiveURLGenerator.swift */,
 				96BAF7D1219BD0C0004B512D /* InternetArchiveQuery.swift */,
 				96ECE0FB2192A0EF00A0C8A6 /* InternetArchiveResponse.swift */,
 				96BAF7D3219BD4F7004B512D /* InternetArchiveProtocols.swift */,
@@ -263,7 +267,7 @@
 				9669B0162197B44300E7CE2A /* MockResponse */,
 				96ECE0E621913AE200A0C8A6 /* InternetArchiveKitTests.swift */,
 				960BE3DB21AE5D170044C142 /* InternetArchiveQueryTests.swift */,
-				96E54CEA2198054F000B9B75 /* APIControllerTests.swift */,
+				96E54CEA2198054F000B9B75 /* URLGeneratorTests.swift */,
 				968C834B219A987C00B89646 /* ModelFieldTests.swift */,
 				9614038C226538E6001B9FB7 /* FastISO8601DateFormatterTests.swift */,
 				96ECE0E821913AE200A0C8A6 /* Info.plist */,
@@ -473,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9667924F22683635005005A6 /* InternetArchiveURLGenerator.swift in Sources */,
 				96ECE0FC2192A0EF00A0C8A6 /* InternetArchiveResponse.swift in Sources */,
 				96BAF7D6219BD518004B512D /* InternetArchiveErrors.swift in Sources */,
 				9614039222654AA4001B9FB7 /* ModelFieldTypes.swift in Sources */,
@@ -495,13 +500,14 @@
 				968C834C219A987C00B89646 /* ModelFieldTests.swift in Sources */,
 				961F158D2249FF6500D874EE /* InternetArchiveProtocols.swift in Sources */,
 				961F158E2249FF7100D874EE /* InternetArchiveResponse.swift in Sources */,
+				968EBEAF2268CAE300AE593D /* InternetArchiveURLGenerator.swift in Sources */,
 				961F158F2249FF7A00D874EE /* InternetArchiveQuery.swift in Sources */,
 				9614039322654BAE001B9FB7 /* ModelFieldTypes.swift in Sources */,
 				961F1592224A001D00D874EE /* Item.swift in Sources */,
 				961F1591224A001700D874EE /* DateParser.swift in Sources */,
 				961F158B2249FF4F00D874EE /* ModelField.swift in Sources */,
 				961F15902249FF8400D874EE /* ItemMetadata.swift in Sources */,
-				96E54CEB2198054F000B9B75 /* APIControllerTests.swift in Sources */,
+				96E54CEB2198054F000B9B75 /* URLGeneratorTests.swift in Sources */,
 				96140390226539EE001B9FB7 /* FastISO8601DateParser.swift in Sources */,
 				960BE3DC21AE5D170044C142 /* InternetArchiveQueryTests.swift in Sources */,
 				961F1593224A002A00D874EE /* File.swift in Sources */,

--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -37,7 +37,7 @@ let logSubsystemId: String = "engineering.astral.internetarchivekit"
  */
 public class InternetArchive: InternetArchiveProtocol {
   public convenience init() {
-    let urlGenerator = URLGenerator(host: "archive.org", scheme: "https")
+    let urlGenerator = URLGenerator()
     self.init(urlGenerator: urlGenerator, urlSession: URLSession.shared)
   }
 
@@ -137,8 +137,13 @@ public class InternetArchive: InternetArchiveProtocol {
         NSLog("makeRequest completed in %f s, url: %@", timeElapsed, url.absoluteString)
       }
 
-      guard let data = data else {
+      guard error == nil else {
         completion(nil, error)
+        return
+      }
+
+      guard let data = data else {
+        completion(nil, InternetArchiveError.noDataReturned)
         return
       }
 

--- a/InternetArchiveKit/InternetArchiveErrors.swift
+++ b/InternetArchiveKit/InternetArchiveErrors.swift
@@ -14,5 +14,6 @@ extension InternetArchive {
    */
   public enum InternetArchiveError: Error {
     case invalidUrl
+    case noDataReturned
   }
 }

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -21,9 +21,28 @@ public protocol InternetArchiveProtocol {
               completion: @escaping (InternetArchive.SearchResponse?, Error?) -> Void)
   func itemDetail(identifier: String,
                   completion: @escaping (InternetArchive.Item?, Error?) -> Void)
+  @available(*, deprecated, message: "Use InternetArchive.URLGenerator instead")
+  func generateItemImageUrl(itemIdentifier: String) -> URL?
+  @available(*, deprecated, message: "Use InternetArchive.URLGenerator instead")
+  func generateMetadataUrl(identifier: String) -> URL?
+  @available(*, deprecated, message: "Use InternetArchive.URLGenerator instead")
+  func generateDownloadUrl(itemIdentifier: String, fileName: String) -> URL?
+}
+
+/**
+ A protocol to which the main `InternetArchive.URLGenerator` class conforms
+ */
+public protocol InternetArchiveURLGeneratorProtocol {
   func generateItemImageUrl(itemIdentifier: String) -> URL?
   func generateMetadataUrl(identifier: String) -> URL?
   func generateDownloadUrl(itemIdentifier: String, fileName: String) -> URL?
+  // swiftlint:disable:next function_parameter_count
+  func generateSearchUrl(query: InternetArchiveURLStringProtocol,
+                         page: Int,
+                         rows: Int,
+                         fields: [String],
+                         sortFields: [InternetArchiveURLQueryItemProtocol],
+                         additionalQueryParams: [URLQueryItem]) -> URL?
 }
 
 /**

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension InternetArchive {
   public class URLGenerator: InternetArchiveURLGeneratorProtocol {
-    init(host: String, scheme: String) {
+    init(host: String = "archive.org", scheme: String = "https") {
       self.host = host
       self.scheme = scheme
     }

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -1,0 +1,94 @@
+//
+//  InternetArchiveURLGenerators.swift
+//  InternetArchiveKit
+//
+//  Created by Jason Buckner on 4/17/19.
+//  Copyright © 2019 Jason Buckner. All rights reserved.
+//
+
+import Foundation
+
+extension InternetArchive {
+  public class URLGenerator: InternetArchiveURLGeneratorProtocol {
+    init(host: String, scheme: String) {
+      self.host = host
+      self.scheme = scheme
+    }
+
+    /**
+     Generate the metadata url for an Internet Archive search
+
+     - parameters:
+     - identifier: The item identifier
+
+     - returns: Optional metadata `URL`
+     */
+    public func generateMetadataUrl(identifier: String) -> URL? {
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/metadata/\(identifier)"
+      return urlComponents.url
+    }
+
+    /**
+     Generate the item image url for an Internet Archive item
+
+     - parameters:
+     - itemIdentifier: The item identifier
+
+     - returns: Optional item image `URL`
+     */
+    public func generateItemImageUrl(itemIdentifier: String) -> URL? {
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/services/img/\(itemIdentifier)"
+      return urlComponents.url
+    }
+
+    /**
+     Generate the download url for an Internet Archive file
+
+     - parameters:
+     - itemIdentifier: The item identifier
+     - fileName: The file name
+
+     - returns: Optional file download `URL`
+     */
+    public func generateDownloadUrl(itemIdentifier: String, fileName: String) -> URL? {
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/download/\(itemIdentifier)/\(fileName)"
+      return urlComponents.url
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    public func generateSearchUrl(query: InternetArchiveURLStringProtocol,
+                                  page: Int,
+                                  rows: Int,
+                                  fields: [String],
+                                  sortFields: [InternetArchiveURLQueryItemProtocol],
+                                  additionalQueryParams: [URLQueryItem]) -> URL? {
+
+      let fieldParams: [URLQueryItem] = fields.compactMap { URLQueryItem(name: "fl[]", value: $0) }
+      let sortParams: [URLQueryItem] = sortFields.compactMap { $0.asQueryItem }
+      let params: [URLQueryItem] = sortParams + fieldParams + additionalQueryParams + [
+        URLQueryItem(name: "q", value: query.asURLString),
+        URLQueryItem(name: "output", value: "json"),
+        URLQueryItem(name: "rows", value: "\(rows)"),
+        URLQueryItem(name: "page", value: "\(page)")
+      ]
+
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/advancedsearch.php"
+      urlComponents.queryItems = params
+      return urlComponents.url
+    }
+
+    private func getBaseUrlComponents() -> URLComponents {
+      var urlComponents: URLComponents = URLComponents()
+      urlComponents.scheme = scheme
+      urlComponents.host = host
+      return urlComponents
+    }
+
+    private let host: String
+    private let scheme: String
+  }
+}

--- a/InternetArchiveKitTests/URLGeneratorTests.swift
+++ b/InternetArchiveKitTests/URLGeneratorTests.swift
@@ -11,24 +11,16 @@ import XCTest
 
 class APIControllerTests: XCTestCase {
 
-  override func setUp() {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-  }
-
-  override func tearDown() {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
   func testGenerateSearchUrl() {
-    let internetArchive: InternetArchive = InternetArchive(host: "foohost.org", scheme: "gopher", urlSession: URLSession.shared)
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
     let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar", "baz": "boop"])
     let sortField: InternetArchive.SortField = InternetArchive.SortField(field: "foo", direction: .asc)
-    if let url: URL = internetArchive.generateSearchUrl(query: query,
-                                                      page: 0,
-                                                      rows: 10,
-                                                      fields: ["foo", "bar"],
-                                                      sortFields: [sortField],
-                                                      additionalQueryParams: []) {
+    if let url: URL = urlGenerator.generateSearchUrl(query: query,
+                                                     page: 0,
+                                                     rows: 10,
+                                                     fields: ["foo", "bar"],
+                                                     sortFields: [sortField],
+                                                     additionalQueryParams: []) {
       let absoluteUrl: String = url.absoluteString
       debugPrint(absoluteUrl)
       // these are not necessarily always in the same order so just search
@@ -45,8 +37,8 @@ class APIControllerTests: XCTestCase {
   }
 
   func testGenerateDownloadUrl() {
-    let internetArchive: InternetArchive = InternetArchive(host: "foohost.org", scheme: "gopher", urlSession: URLSession.shared)
-    if let url: URL = internetArchive.generateDownloadUrl(itemIdentifier: "foo", fileName: "bar") {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    if let url: URL = urlGenerator.generateDownloadUrl(itemIdentifier: "foo", fileName: "bar") {
       XCTAssertEqual(url.absoluteString, "gopher://foohost.org/download/foo/bar")
     } else {
       XCTFail("Error generating download URL")
@@ -54,11 +46,21 @@ class APIControllerTests: XCTestCase {
   }
 
   func testGenerateImageUrl() {
-    let internetArchive: InternetArchive = InternetArchive(host: "foohost.org", scheme: "gopher", urlSession: URLSession.shared)
-    if let url: URL = internetArchive.generateItemImageUrl(itemIdentifier: "foo") {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    if let url: URL = urlGenerator.generateItemImageUrl(itemIdentifier: "foo") {
       XCTAssertEqual(url.absoluteString, "gopher://foohost.org/services/img/foo")
     } else {
       XCTFail("Error generating download URL")
     }
   }
+
+  func testGenerateMetadataUrl() {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    if let url: URL = urlGenerator.generateMetadataUrl(identifier: "foo") {
+      XCTAssertEqual(url.absoluteString, "gopher://foohost.org/metadata/foo")
+    } else {
+      XCTFail("Error generating download URL")
+    }
+  }
+
 }


### PR DESCRIPTION
This extracts the URL generation from the `InternetArchive` class. This keeps the `InternetArchive` more single-purpose (search and fetch items) and allows for more thorough testability.