### PR TITLE
Disable Codecov.io Coverage for Tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "InternetArchiveKitTests"


### PR DESCRIPTION
Codecov.io was including code coverage for tests, which lowered the percentage of "actual" test coverage