### PR TITLE
Query Improvements

### DIFF
--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -60,5 +60,3 @@ public protocol InternetArchiveURLStringProtocol {
 public protocol InternetArchiveURLQueryItemProtocol {
   var asQueryItem: URLQueryItem { get }
 }
-
-public protocol InternetArchiveQueryClauseProtocol: InternetArchiveURLStringProtocol {}

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -38,23 +38,32 @@ extension InternetArchive {
    ```
   */
   public struct Query: InternetArchiveURLStringProtocol {
-    public var clauses: [InternetArchiveQueryClauseProtocol]
+    public var clauses: [InternetArchiveURLStringProtocol]
     public var asURLString: String { // eg `collection:(etree) AND -title:(foo)`
       let paramStrings: [String] = clauses.compactMap { $0.asURLString }
-      return paramStrings.joined(separator: " AND ")
+      let joinedClauses = paramStrings.joined(separator: " \(booleanOperator.rawValue) ")
+      let surroundedClauses = "(\(joinedClauses))"
+      return surroundedClauses
     }
+    public let booleanOperator: QueryBooleanOperator
 
-    // Convenience initializer to just pass in a bunch of key:values. Only handles boolean AND cases
-    public init(clauses: [String: String]) {
+    // Convenience initializer to just pass in a bunch of key:values
+    public init(clauses: [String: String], booleanOperator: QueryBooleanOperator = .and) {
       let params: [QueryClause] = clauses.compactMap { (param: (field: String, value: String)) -> QueryClause? in
         return QueryClause(field: param.field, value: param.value)
       }
-      self.init(clauses: params)
+      self.init(clauses: params, booleanOperator: booleanOperator)
     }
 
-    public init(clauses: [InternetArchiveQueryClauseProtocol]) {
+    public init(clauses: [InternetArchiveURLStringProtocol], booleanOperator: QueryBooleanOperator = .and) {
       self.clauses = clauses
+      self.booleanOperator = booleanOperator
     }
+  }
+
+  public enum QueryBooleanOperator: String {
+    case and = "AND"
+    case or = "OR" // swiftlint:disable:this identifier_name
   }
 
   /**
@@ -71,19 +80,25 @@ extension InternetArchive {
    let clause2 = InternetArchive.QueryClause(field: "bar", value: "foo", booleanOperator: .not)
    ```
    */
-  public struct QueryClause: InternetArchiveQueryClauseProtocol {
+  public struct QueryClause: InternetArchiveURLStringProtocol {
     public let field: String
-    public let value: String
-    public let booleanOperator: BooleanOperator
-    public var asURLString: String { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`
+    public let values: [String]
+    public let booleanOperator: QueryClauseBooleanOperator
+    public var asURLString: String { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`, `identifier:(foo OR bar)`
       let urlKey: String = field.count > 0 ? "\(field):" : ""
-      return "\(booleanOperator.rawValue)\(urlKey)(\(value))"
+      let joinedValues = values.joined(separator: " OR ")
+      return "\(booleanOperator.rawValue)\(urlKey)(\(joinedValues))"
+    }
+
+    // convenience initializer for single-values
+    public init(field: String, value: String, booleanOperator: QueryClauseBooleanOperator = .and) {
+      self.init(field: field, values: [value], booleanOperator: booleanOperator)
     }
 
     // field can be empty if you just want to search
-    public init(field: String, value: String, booleanOperator: BooleanOperator = .and) {
+    public init(field: String, values: [String], booleanOperator: QueryClauseBooleanOperator = .and) {
       self.field = field
-      self.value = value
+      self.values = values
       self.booleanOperator = booleanOperator
     }
   }
@@ -102,7 +117,7 @@ extension InternetArchive {
    let dateRangeClause = InternetArchive.QueryDateRange(queryField: "date", dateRange: dateInterval)
    ```
    */
-  public struct QueryDateRange: InternetArchiveQueryClauseProtocol {
+  public struct QueryDateRange: InternetArchiveURLStringProtocol {
     public let queryField: String
     public let dateRange: DateInterval
     public var asURLString: String { // eg `date:[2018-01-01T07:23:12Z TO 2018-04-01T17:53:34Z]`
@@ -125,7 +140,7 @@ extension InternetArchive {
     }
   }
 
-  public enum BooleanOperator: String {
+  public enum QueryClauseBooleanOperator: String {
     case and = ""
     case not = "-" // if we want negate this query clause, put a minus before it, ie: `-collection:(foo)`
   }

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -27,6 +27,18 @@ extension InternetArchive {
    let query = InternetArchive.Query(clauses: ["": "etree"])
    ```
 
+   ### Sub-queries:
+   ```
+   let clause1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "bar")
+   let clause2: InternetArchive.QueryClause = InternetArchive.QueryClause(
+     field: "baz", value: "boop", booleanOperator: .not)
+   let query: InternetArchive.Query = InternetArchive.Query(clauses: [clause1, clause2])
+   let clause3: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "snip", value: "snap")
+   let subQuery: InternetArchive.Query = InternetArchive.Query(clauses: [query, clause3], booleanOperator: .or)
+
+   subQuery => "((foo:(bar) AND -baz:(boop)) OR snip:(snap))"
+   ```
+
    ### Advanced Usage:
    ```
    let clause1 = InternetArchive.QueryClause(field: "title", value: "String Cheese", booleanOperator: .and)
@@ -76,8 +88,10 @@ extension InternetArchive {
 
    ### Example Usage:
    ```
-   let clause1 = InternetArchive.QueryClause(field: "foo", value: "bar", booleanOperator: .and)
-   let clause2 = InternetArchive.QueryClause(field: "bar", value: "foo", booleanOperator: .not)
+   let clause1 = InternetArchive.QueryClause(field: "foo", value: "bar", booleanOperator: .and) => foo:(var)
+   let clause2 = InternetArchive.QueryClause(field: "bar", value: "foo", booleanOperator: .not) => -bar:(foo)
+   let clause3 = InternetArchive.QueryClause(field: "bar", value: "foo", exactMatch: true) => bar:"foo"
+   let clause4 = InternetArchive.QueryClause(field: "foo", values: ["bar", "baz"]) => foo:(bar OR baz)
    ```
    */
   public struct QueryClause: InternetArchiveURLStringProtocol {

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -83,23 +83,41 @@ extension InternetArchive {
   public struct QueryClause: InternetArchiveURLStringProtocol {
     public let field: String
     public let values: [String]
+    public let exactMatch: Bool
     public let booleanOperator: QueryClauseBooleanOperator
     public var asURLString: String { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`, `identifier:(foo OR bar)`
-      let urlKey: String = field.count > 0 ? "\(field):" : ""
+      let fieldKey: String = field.count > 0 ? "\(field):" : ""
       let joinedValues = values.joined(separator: " OR ")
-      return "\(booleanOperator.rawValue)\(urlKey)(\(joinedValues))"
+      let valueString: String
+      if exactMatch {
+        valueString = "\"\(joinedValues)\""
+      } else {
+        valueString = "(\(joinedValues))"
+      }
+      return "\(booleanOperator.rawValue)\(fieldKey)\(valueString)"
     }
 
     // convenience initializer for single-values
-    public init(field: String, value: String, booleanOperator: QueryClauseBooleanOperator = .and) {
-      self.init(field: field, values: [value], booleanOperator: booleanOperator)
+    public init(
+      field: String,
+      value: String,
+      booleanOperator: QueryClauseBooleanOperator = .and,
+      exactMatch: Bool = false
+    ) {
+      self.init(field: field, values: [value], booleanOperator: booleanOperator, exactMatch: exactMatch)
     }
 
     // field can be empty if you just want to search
-    public init(field: String, values: [String], booleanOperator: QueryClauseBooleanOperator = .and) {
+    public init(
+      field: String,
+      values: [String],
+      booleanOperator: QueryClauseBooleanOperator = .and,
+      exactMatch: Bool = false
+    ) {
       self.field = field
       self.values = values
       self.booleanOperator = booleanOperator
+      self.exactMatch = exactMatch
     }
   }
 

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -40,6 +40,18 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(clause.asURLString, "-foo:(bar OR baz)")
   }
 
+  func testQueryClauseExactMatch() {
+    let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+      field: "foo", value: "bar", exactMatch: true)
+    XCTAssertEqual(clause.asURLString, "foo:\"bar\"")
+  }
+
+  func testQueryClauseMultiValueExactMatch() {
+    let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+      field: "foo", values: ["bar", "baz"], exactMatch: true)
+    XCTAssertEqual(clause.asURLString, "foo:\"bar OR baz\"")
+  }
+
   func testSubQueryString() {
     let param1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "bar")
     let param2: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "baz", value: "boop", booleanOperator: .not)

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -61,6 +61,17 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(subQuery.asURLString, "((foo:(bar) AND -baz:(boop)) OR snip:(snap))")
   }
 
+  func testMoreSubQueryStrings() {
+    let param1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "bar")
+    let param2: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "baz", value: "boop", booleanOperator: .not)
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: [param1, param2])
+    let param3: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "snip", value: "snap")
+    let param4: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "blop", value: "blap")
+    let query2: InternetArchive.Query = InternetArchive.Query(clauses: [param3, param4])
+    let subQuery: InternetArchive.Query = InternetArchive.Query(clauses: [query, query2], booleanOperator: .or)
+    XCTAssertEqual(subQuery.asURLString, "((foo:(bar) AND -baz:(boop)) OR (snip:(snap) AND blop:(blap)))")
+  }
+
   func testQueryStringConvenience() {
     let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar", "baz": "boop"])
     let queryAsUrl: String = query.asURLString

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -26,19 +26,69 @@ class InternetArchiveQueryTests: XCTestCase {
     let param3: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "", value: "boop")
     let query: InternetArchive.Query = InternetArchive.Query(clauses: [param1, param2, param3])
 
-    XCTAssertEqual(query.asURLString, "foo:(bar) AND -baz:(boop) AND (boop)")
+    XCTAssertEqual(query.asURLString, "(foo:(bar) AND -baz:(boop) AND (boop))")
+  }
+
+  func testQueryClauseMultipleValues() {
+    let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", values: ["bar", "baz", "boop"])
+    XCTAssertEqual(clause.asURLString, "foo:(bar OR baz OR boop)")
+  }
+
+  func testQueryClauseMultipleValuesNegative() {
+    let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+      field: "foo", values: ["bar", "baz"], booleanOperator: .not)
+    XCTAssertEqual(clause.asURLString, "-foo:(bar OR baz)")
+  }
+
+  func testSubQueryString() {
+    let param1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "bar")
+    let param2: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "baz", value: "boop", booleanOperator: .not)
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: [param1, param2])
+    let param3: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "snip", value: "snap")
+    let subQuery: InternetArchive.Query = InternetArchive.Query(clauses: [query, param3], booleanOperator: .or)
+    XCTAssertEqual(subQuery.asURLString, "((foo:(bar) AND -baz:(boop)) OR snip:(snap))")
   }
 
   func testQueryStringConvenience() {
     let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar", "baz": "boop"])
     let queryAsUrl: String = query.asURLString
-    XCTAssertTrue(queryAsUrl == "foo:(bar) AND baz:(boop)" || queryAsUrl == "baz:(boop) AND foo:(bar)")
+    XCTAssertTrue(queryAsUrl == "(foo:(bar) AND baz:(boop))" || queryAsUrl == "(baz:(boop) AND foo:(bar))")
     let query2: InternetArchive.Query = InternetArchive.Query(clauses: ["": "bar", "baz": "boop"])
     let query2AsUrl: String = query2.asURLString
-    XCTAssertTrue(query2AsUrl == "(bar) AND baz:(boop)" || query2AsUrl == "baz:(boop) AND (bar)")
+    XCTAssertTrue(query2AsUrl == "((bar) AND baz:(boop))" || query2AsUrl == "(baz:(boop) AND (bar))")
     let query3: InternetArchive.Query = InternetArchive.Query(clauses: ["-foo": "bar", "baz": "boop"])
     let query3AsUrl: String = query3.asURLString
-    XCTAssertTrue(query3AsUrl == "-foo:(bar) AND baz:(boop)" || query3AsUrl == "baz:(boop) AND -foo:(bar)")
+    XCTAssertTrue(query3AsUrl == "(-foo:(bar) AND baz:(boop))" || query3AsUrl == "(baz:(boop) AND -foo:(bar))")
+  }
+
+  func testQueryBooleanOr() {
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["foo": "bar", "baz": "boop"], booleanOperator: .or)
+    let queryAsUrl: String = query.asURLString
+    debugPrint(queryAsUrl)
+    XCTAssertTrue(queryAsUrl == "(foo:(bar) OR baz:(boop))" || queryAsUrl == "(baz:(boop) OR foo:(bar))")
+    let query2: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["": "bar", "baz": "boop"], booleanOperator: .or)
+    let query2AsUrl: String = query2.asURLString
+    XCTAssertTrue(query2AsUrl == "((bar) OR baz:(boop))" || query2AsUrl == "(baz:(boop) OR (bar))")
+    let query3: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["-foo": "bar", "baz": "boop"], booleanOperator: .or)
+    let query3AsUrl: String = query3.asURLString
+    XCTAssertTrue(query3AsUrl == "(-foo:(bar) OR baz:(boop))" || query3AsUrl == "(baz:(boop) OR -foo:(bar))")
+  }
+
+  func testSubQuery() {
+    let query1: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["foo": "bar", "baz": "boop"], booleanOperator: .or)
+    let queryClause: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "snip", value: "snap")
+    let mergedQuery = InternetArchive.Query(clauses: [query1, queryClause])
+    let queryAsUrl = mergedQuery.asURLString
+    XCTAssertTrue(
+      queryAsUrl == "((foo:(bar) OR baz:(boop)) AND snip:(snap))" ||
+      queryAsUrl == "((baz:(boop) OR foo:(bar)) AND snip:(snap))" ||
+      queryAsUrl == "snip:(snap)) AND ((foo:(bar) OR baz:(boop))" ||
+      queryAsUrl == "snip:(snap)) AND ((baz:(boop) OR foo:(bar))"
+    )
   }
 
   func testDateRangeQuery() {
@@ -73,6 +123,4 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(sortField.asQueryItem.name, "sort[]")
     XCTAssertEqual(sortField.asQueryItem.value, "foo desc")
   }
-
-
 }

--- a/InternetArchiveKitTests/URLGeneratorTests.swift
+++ b/InternetArchiveKitTests/URLGeneratorTests.swift
@@ -27,7 +27,7 @@ class APIControllerTests: XCTestCase {
       XCTAssertTrue(absoluteUrl.contains("sort%5B%5D=foo%20asc"))
       XCTAssertTrue(absoluteUrl.contains("fl%5B%5D=foo"))
       XCTAssertTrue(absoluteUrl.contains("fl%5B%5D=bar"))
-      XCTAssertTrue(absoluteUrl.contains("q=foo:(bar)%20AND%20baz:(boop)") || absoluteUrl.contains("q=baz:(boop)%20AND%20foo:(bar)"))
+      XCTAssertTrue(absoluteUrl.contains("q=(foo:(bar)%20AND%20baz:(boop))") || absoluteUrl.contains("q=(baz:(boop)%20AND%20foo:(bar))"))
       XCTAssertTrue(absoluteUrl.contains("output=json"))
       XCTAssertTrue(absoluteUrl.contains("rows=10"))
       XCTAssertTrue(absoluteUrl.contains("page=0"))


### PR DESCRIPTION
# Add support for more complex queries

## Multi-value matching
Match multiple values for a given key. Previously if you wanted to match multiple values, you had to construct a query like this: `identifier:(foo) OR identifier:(bar)`
Now you can construct a query like this: `identifier:(foo OR bar)`

## Exact Matches
Previously, all matches were "similar" in that they were wrapped in parentheses, ie: `identifier:(foo)`. Now you can specify `exactMatch: true` to generate an `identifier:"foo"` query.

## Sub-query Support
Now you can do fairly complex subqueries like `((foo:(bar OR baz) AND -boop:(blop)) OR snip:"snap")`