### PR TITLE
Make asURLString() optional

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -72,7 +72,7 @@ public class InternetArchive: InternetArchiveProtocol {
       query: query, page: page, rows: rows, fields: fields ?? [], sortFields: sortFields ?? [],
       additionalQueryParams: [])
       else {
-        os_log("search error generating metadata url: %{public}@", log: log, type: .error, query.asURLString)
+        os_log("search error generating metadata url: %{public}@", log: log, type: .error, query.asURLString ?? "")
       completion(nil, InternetArchiveError.invalidUrl)
       return
     }

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -45,7 +45,7 @@ public protocol InternetArchiveURLGeneratorProtocol {
  All of the search queries components like Query and DateQuery conform to this
  */
 public protocol InternetArchiveURLStringProtocol {
-  var asURLString: String { get }
+  var asURLString: String? { get }
 }
 
 /**

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -51,7 +51,8 @@ extension InternetArchive {
   */
   public struct Query: InternetArchiveURLStringProtocol {
     public var clauses: [InternetArchiveURLStringProtocol]
-    public var asURLString: String { // eg `collection:(etree) AND -title:(foo)`
+    public var asURLString: String? { // eg `collection:(etree) AND -title:(foo)`
+      guard clauses.count > 0 else { return nil }
       let paramStrings: [String] = clauses.compactMap { $0.asURLString }
       let joinedClauses = paramStrings.joined(separator: " \(booleanOperator.rawValue) ")
       let surroundedClauses = "(\(joinedClauses))"
@@ -99,7 +100,7 @@ extension InternetArchive {
     public let values: [String]
     public let exactMatch: Bool
     public let booleanOperator: QueryClauseBooleanOperator
-    public var asURLString: String { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`, `identifier:(foo OR bar)`
+    public var asURLString: String? { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`, `identifier:(foo OR bar)`
       let fieldKey: String = field.count > 0 ? "\(field):" : ""
       let surroundedValues = values.compactMap { (value: String) -> String? in
         return exactMatch ? "\"\(value)\"" : "(\(value))"
@@ -150,7 +151,7 @@ extension InternetArchive {
   public struct QueryDateRange: InternetArchiveURLStringProtocol {
     public let queryField: String
     public let dateRange: DateInterval
-    public var asURLString: String {
+    public var asURLString: String? {
       let startDate: Date = dateRange.start
       let endDate: Date = dateRange.end
       let dateFormatter: DateFormatter = DateFormatter()
@@ -192,7 +193,7 @@ extension InternetArchive {
     public let queryField: String
     public let rangeStart: Double
     public let rangeEnd: Double
-    public var asURLString: String {
+    public var asURLString: String? {
       let startString: String = rangeStart.truncatingRemainder(dividingBy: 1) == 0 ?
         "\(Int(rangeStart))" : "\(rangeStart)"
       let endString: String = rangeEnd.truncatingRemainder(dividingBy: 1) == 0 ?
@@ -230,7 +231,7 @@ extension InternetArchive {
     public let queryField: String
     public let rangeStart: String
     public let rangeEnd: String
-    public var asURLString: String {
+    public var asURLString: String? {
       return QueryRangeFormatter.formatRangeString(
         queryField: queryField,
         rangeStart: "\(rangeStart)",

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -29,6 +29,11 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(query.asURLString, "(foo:(bar) AND -baz:(boop) AND (boop))")
   }
 
+  func testEmptyQueryClauseReturnsNil() {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: [])
+    XCTAssertEqual(query.asURLString, nil)
+  }
+
   func testQueryClauseMultipleValues() {
     let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", values: ["bar", "baz", "boop"])
     XCTAssertEqual(clause.asURLString, "foo:((bar) OR (baz) OR (boop))")
@@ -74,29 +79,28 @@ class InternetArchiveQueryTests: XCTestCase {
 
   func testQueryStringConvenience() {
     let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar", "baz": "boop"])
-    let queryAsUrl: String = query.asURLString
+    let queryAsUrl: String? = query.asURLString
     XCTAssertTrue(queryAsUrl == "(foo:(bar) AND baz:(boop))" || queryAsUrl == "(baz:(boop) AND foo:(bar))")
     let query2: InternetArchive.Query = InternetArchive.Query(clauses: ["": "bar", "baz": "boop"])
-    let query2AsUrl: String = query2.asURLString
+    let query2AsUrl: String? = query2.asURLString
     XCTAssertTrue(query2AsUrl == "((bar) AND baz:(boop))" || query2AsUrl == "(baz:(boop) AND (bar))")
     let query3: InternetArchive.Query = InternetArchive.Query(clauses: ["-foo": "bar", "baz": "boop"])
-    let query3AsUrl: String = query3.asURLString
+    let query3AsUrl: String? = query3.asURLString
     XCTAssertTrue(query3AsUrl == "(-foo:(bar) AND baz:(boop))" || query3AsUrl == "(baz:(boop) AND -foo:(bar))")
   }
 
   func testQueryBooleanOr() {
     let query: InternetArchive.Query = InternetArchive.Query(
       clauses: ["foo": "bar", "baz": "boop"], booleanOperator: .or)
-    let queryAsUrl: String = query.asURLString
-    debugPrint(queryAsUrl)
+    let queryAsUrl: String? = query.asURLString
     XCTAssertTrue(queryAsUrl == "(foo:(bar) OR baz:(boop))" || queryAsUrl == "(baz:(boop) OR foo:(bar))")
     let query2: InternetArchive.Query = InternetArchive.Query(
       clauses: ["": "bar", "baz": "boop"], booleanOperator: .or)
-    let query2AsUrl: String = query2.asURLString
+    let query2AsUrl: String? = query2.asURLString
     XCTAssertTrue(query2AsUrl == "((bar) OR baz:(boop))" || query2AsUrl == "(baz:(boop) OR (bar))")
     let query3: InternetArchive.Query = InternetArchive.Query(
       clauses: ["-foo": "bar", "baz": "boop"], booleanOperator: .or)
-    let query3AsUrl: String = query3.asURLString
+    let query3AsUrl: String? = query3.asURLString
     XCTAssertTrue(query3AsUrl == "(-foo:(bar) OR baz:(boop))" || query3AsUrl == "(baz:(boop) OR -foo:(bar))")
   }
 


### PR DESCRIPTION
Previously, if no clauses were passed into the InternetArchive.Query, calling .asURLString() would generate empty parentheses `()`. This produced an invalid query string. Now asURLString is optional so if we encounter nil URL strings, we can just skip them.