### PR TITLE
WIP: Replace regex characters in fuzzy match

### DIFF
--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -102,11 +102,25 @@ extension InternetArchive {
     public var asURLString: String { // eg `collection:(etree)`, `-title:(foo)`, `(bar)`, `identifier:(foo OR bar)`
       let fieldKey: String = field.count > 0 ? "\(field):" : ""
       let surroundedValues = values.compactMap { (value: String) -> String? in
-        return exactMatch ? "\"\(value)\"" : "(\(value))"
+        if exactMatch {
+          return "\"\(value)\""
+        }
+
+        let regexFixed = quoteRegexCharacters(string: value)
+        return "(\(regexFixed))"
       }
       let joinedValues = surroundedValues.joined(separator: " OR ")
       let finalValue = values.count == 1 ? joinedValues : "(\(joinedValues))"
       return "\(booleanOperator.rawValue)\(fieldKey)\(finalValue)"
+    }
+
+    private let regexReplacementStrings = [":", "[", "]", "(", ")", "OR", "or", "AND", "and"]
+    private func quoteRegexCharacters(string: String) -> String {
+      var normalized = string
+      regexReplacementStrings.forEach {
+        normalized = normalized.replacingOccurrences(of: $0, with: "\"\($0)\"")
+      }
+      return normalized
     }
 
     // convenience initializer for single-values
@@ -116,7 +130,12 @@ extension InternetArchive {
       booleanOperator: QueryClauseBooleanOperator = .and,
       exactMatch: Bool = false
     ) {
-      self.init(field: field, values: [value], booleanOperator: booleanOperator, exactMatch: exactMatch)
+      self.init(
+        field: field,
+        values: [value],
+        booleanOperator: booleanOperator,
+        exactMatch: exactMatch
+      )
     }
 
     // field can be empty if you just want to search

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -52,6 +52,34 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(clause.asURLString, "foo:(\"bar\" OR \"baz\")")
   }
 
+  func testQueryClauseExactMatchDoesNotModifyRegexChars() {
+    let replacementStrings = [":", "[", "]", "(", ")", "OR", "or", "AND", "and"]
+
+    replacementStrings.forEach {
+      let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+        field: "foo", values: ["\($0)boop\($0)"], exactMatch: true)
+      XCTAssertEqual(clause.asURLString, "foo:\"\($0)boop\($0)\"")
+    }
+  }
+
+  func testQueryClauseFuzzyMatchRegexFix() {
+    let replacementStrings = [":", "[", "]", "(", ")", "OR", "or", "AND", "and"]
+
+    replacementStrings.forEach {
+      let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+        field: "foo", values: ["\($0)boop\($0)"], exactMatch: false)
+      XCTAssertEqual(clause.asURLString, "foo:(\"\($0)\"boop\"\($0)\")")
+    }
+  }
+
+  func testMultipleQueryClauseFuzzyMatchRegexFix() {
+    let param1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "(bar)", booleanOperator: .and, exactMatch: false)
+    let param2: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "baz", value: "[boop]", booleanOperator: .not, exactMatch: true)
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: [param1, param2])
+
+    XCTAssertEqual(query.asURLString, "(foo:(\"(\"bar\")\") AND -baz:\"[boop]\")")
+  }
+
   func testSubQueryString() {
     let param1: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "foo", value: "bar")
     let param2: InternetArchive.QueryClause = InternetArchive.QueryClause(field: "baz", value: "boop", booleanOperator: .not)


### PR DESCRIPTION
When we do a fuzzy match, ie `venue:(foo fest [bar stage])` we need to remove any regex characters from the string or else the search engine throws a regex error. We will now replace the `[` and `]` with `"["` and `"]"`. The final query string will be `venue:(foo fest "["bar stage"]")`.