### PR TITLE
Fix issue with reviewbody decoding

### DIFF
--- a/InternetArchiveKit/Models/Review.swift
+++ b/InternetArchiveKit/Models/Review.swift
@@ -12,7 +12,7 @@ extension InternetArchive {
    A review on an Internet Archive item
    */
   public struct Review: Decodable {
-    public let reviewbody: String?
+    public let reviewbody: ModelField<IAString>?
     public let reviewtitle: String?
     public let reviewer: String?
     public let reviewer_itemname: String?
@@ -21,7 +21,7 @@ extension InternetArchive {
     public let stars: ModelField<IADouble>?
 
     public init(
-      reviewbody: String? = nil,
+      reviewbody: ModelField<IAString>? = nil,
       reviewtitle: String? = nil,
       reviewer: String? = nil,
       reviewer_itemname: String? = nil,


### PR DESCRIPTION
When trying to get details for [https://archive.org/details/adventures_sherlockholmes_1007_librivox](https://archive.org/details/adventures_sherlockholmes_1007_librivox), I was getting a decoding error: `Expected to decode "PKc" but found Array instead`. I didn't look much into how ModelField works and I'm not sure if any other changes are needed besides what I did here, but this seems to fix the issue for me.

PS: Thank you for the amazing job with this library!