### PR TITLE
Surface archive.org HTTP-200 error bodies as apiError; assert on oversized q

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -171,7 +171,7 @@ public class InternetArchive: InternetArchiveProtocol {
         timeElapsed,
         url.absoluteString
       )
-      let results: T = try jsonDecoder.decode(T.self, from: data)
+      let results: T = try decodeResponse(data)
       return .success(results)
     } catch {
       os_log(
@@ -181,6 +181,24 @@ public class InternetArchive: InternetArchiveProtocol {
         error.localizedDescription
       )
       return .failure(error)
+    }
+  }
+
+  /// Decode the expected payload. If that fails and the body is an
+  /// HTTP-200 error envelope (`{"error": "…"}`), surface the API's
+  /// message as `InternetArchiveError.apiError` instead of the
+  /// shape-mismatch decoding error it would otherwise cause.
+  private func decodeResponse<T>(_ data: Data) throws -> T
+  where T: Decodable {
+    do {
+      return try jsonDecoder.decode(T.self, from: data)
+    } catch {
+      if let envelope = try? jsonDecoder.decode(
+        APIErrorEnvelope.self, from: data
+      ) {
+        throw InternetArchiveError.apiError(message: envelope.error)
+      }
+      throw error
     }
   }
 

--- a/InternetArchiveKit/InternetArchiveErrors.swift
+++ b/InternetArchiveKit/InternetArchiveErrors.swift
@@ -12,7 +12,35 @@ extension InternetArchive {
   /**
    Errors that may be returned by the InternetArchive class
    */
-  public enum InternetArchiveError: Error {
+  public enum InternetArchiveError: Error, Equatable {
     case invalidUrl
+
+    /// The API answered HTTP 200 but the body was an error envelope
+    /// (`{"error": "…"}`) instead of the expected payload. archive.org
+    /// signals rejected searches this way — for example a `q` parameter
+    /// over ~2,000 characters returns
+    /// `{"error": "[UNSUPPORTED_VALUE] …"}` with no `response` block.
+    /// `message` carries the API's error string.
+    case apiError(message: String)
+  }
+}
+
+extension InternetArchive.InternetArchiveError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .invalidUrl:
+      return "Invalid URL"
+    case .apiError(let message):
+      return "Internet Archive API error: \(message)"
+    }
+  }
+}
+
+extension InternetArchive {
+  /// The HTTP-200 error envelope shape, e.g.
+  /// `{"error": "[UNSUPPORTED_VALUE] …"}`. Used to distinguish an API
+  /// rejection from a payload-shape decoding failure in `makeRequest`.
+  struct APIErrorEnvelope: Decodable {
+    let error: String
   }
 }

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -7,9 +7,17 @@
 //
 
 import Foundation
+import os.log
 
 extension InternetArchive {
   public class URLGenerator: InternetArchiveURLGeneratorProtocol {
+    /// archive.org's search gateway rejects `q` values somewhere above
+    /// ~1,900–2,000 characters — HTTP 200 with an `{"error": "…"}` body
+    /// (surfaced as `InternetArchiveError.apiError`). This budget leaves
+    /// headroom below the measured limit; clients batching values into a
+    /// single clause should chunk against it.
+    public static let recommendedMaxQueryLength: Int = 1_800
+
     public init(host: String = "archive.org", scheme: String = "https") {
       self.host = host
       self.scheme = scheme
@@ -68,6 +76,7 @@ extension InternetArchive {
       sortFields: [InternetArchiveURLQueryItemProtocol],
       additionalQueryParams: [URLQueryItem]
     ) -> URL? {
+      warnIfQueryExceedsRecommendedLength(query.asURLString)
 
       let fieldParams: [URLQueryItem] = fields.compactMap {
         URLQueryItem(name: "fl[]", value: $0)
@@ -94,7 +103,40 @@ extension InternetArchive {
       return urlComponents
     }
 
+    /// `true` when the assembled `q` string is over
+    /// `recommendedMaxQueryLength`. Split out from the warning so the
+    /// predicate is testable without tripping `assertionFailure`.
+    static func queryExceedsRecommendedLength(_ queryString: String?) -> Bool {
+      (queryString?.count ?? 0) > recommendedMaxQueryLength
+    }
+
+    /// The request is still sent — the gateway's `{"error": …}` body comes
+    /// back as `InternetArchiveError.apiError` — but an oversized query is
+    /// almost certainly a batching bug, so fail loudly in development.
+    private func warnIfQueryExceedsRecommendedLength(_ queryString: String?) {
+      guard Self.queryExceedsRecommendedLength(queryString),
+            let queryString = queryString else { return }
+      os_log(
+        .error,
+        log: log,
+        "search query is %d chars; archive.org rejects q over ~2,000. Chunk against URLGenerator.recommendedMaxQueryLength (%d). Query prefix: %{public}@",
+        queryString.count,
+        Self.recommendedMaxQueryLength,
+        String(queryString.prefix(120))
+      )
+      assertionFailure(
+        "archive.org search query is \(queryString.count) chars — over the "
+          + "~2,000-char gateway limit. Chunk the query against "
+          + "URLGenerator.recommendedMaxQueryLength."
+      )
+    }
+
     private let host: String
     private let scheme: String
+
+    private let log: OSLog = OSLog(
+      subsystem: logSubsystemId,
+      category: "URLGenerator"
+    )
   }
 }

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -119,7 +119,7 @@ extension InternetArchive {
       os_log(
         .error,
         log: log,
-        "search query is %d chars; archive.org rejects q over ~2,000. Chunk against URLGenerator.recommendedMaxQueryLength (%d). Query prefix: %{public}@",
+        "search query is %{public}d chars; archive.org rejects q over ~2,000. Chunk against URLGenerator.recommendedMaxQueryLength (%{public}d). Query prefix: %{public}@",
         queryString.count,
         Self.recommendedMaxQueryLength,
         String(queryString.prefix(120))

--- a/InternetArchiveKitTests/APIErrorTests.swift
+++ b/InternetArchiveKitTests/APIErrorTests.swift
@@ -1,0 +1,117 @@
+//
+//  APIErrorTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 6/11/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+import URLSessionMock
+@testable import InternetArchiveKit
+
+/// archive.org signals rejected searches (e.g. `q` over ~2,000 chars) as
+/// HTTP 200 with an `{"error": "…"}` body and no `response` block. These
+/// tests cover surfacing that envelope as `InternetArchiveError.apiError`
+/// instead of a shape-mismatch `DecodingError`.
+class APIErrorTests: XCTestCase {
+
+  func testSearchErrorBodySurfacesAPIError() {
+    let expectation = XCTestExpectation(description: "Search Error Body")
+    let errorMessage =
+      "[UNSUPPORTED_VALUE] The value specified in the request is not supported"
+    let json = "{\"error\": \"\(errorMessage)\"}"
+    guard let data: Data = json.data(using: .utf8) else {
+      XCTFail("error encoding json to data")
+      return
+    }
+
+    let urlGenerator = InternetArchive.URLGenerator()
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["collection": "etree"])
+    guard
+      let url = urlGenerator.generateSearchUrl(
+        query: query, page: 1, rows: 10, fields: [], sortFields: [],
+        additionalQueryParams: [])
+    else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: data, headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    archive.search(query: query, page: 1, rows: 10) {
+      (response: InternetArchive.SearchResponse?, error: Error?) in
+      XCTAssertNil(response)
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.apiError(message: errorMessage)
+      )
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testWrongShapeWithoutErrorKeyStaysDecodingError() {
+    let expectation = XCTestExpectation(description: "Wrong Shape Body")
+    // Valid JSON, wrong shape, no top-level "error" key — must NOT be
+    // misclassified as an API error.
+    let json = "{\"unexpected\": true}"
+    guard let data: Data = json.data(using: .utf8) else {
+      XCTFail("error encoding json to data")
+      return
+    }
+
+    let urlGenerator = InternetArchive.URLGenerator()
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["collection": "etree"])
+    guard
+      let url = urlGenerator.generateSearchUrl(
+        query: query, page: 1, rows: 10, fields: [], sortFields: [],
+        additionalQueryParams: [])
+    else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: data, headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    archive.search(query: query, page: 1, rows: 10) {
+      (response: InternetArchive.SearchResponse?, error: Error?) in
+      XCTAssertNil(response)
+      XCTAssertNotNil(error)
+      XCTAssertFalse(error is InternetArchive.InternetArchiveError)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testQueryLengthPredicate() {
+    let max = InternetArchive.URLGenerator.recommendedMaxQueryLength
+    XCTAssertFalse(
+      InternetArchive.URLGenerator.queryExceedsRecommendedLength(nil))
+    XCTAssertFalse(
+      InternetArchive.URLGenerator.queryExceedsRecommendedLength(
+        String(repeating: "a", count: max)))
+    XCTAssertTrue(
+      InternetArchive.URLGenerator.queryExceedsRecommendedLength(
+        String(repeating: "a", count: max + 1)))
+  }
+
+  func testAPIErrorLocalizedDescription() {
+    let error = InternetArchive.InternetArchiveError.apiError(
+      message: "[UNSUPPORTED_VALUE] something")
+    XCTAssertEqual(
+      error.errorDescription,
+      "Internet Archive API error: [UNSUPPORTED_VALUE] something"
+    )
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
   name: "InternetArchiveKit",
   platforms: [
     .iOS(.v13),
-    .macOS(.v10_13)
+    .macOS(.v10_15)
   ],
   products: [
     .library(name: "InternetArchiveKit", targets: ["InternetArchiveKit"])


### PR DESCRIPTION
Fixes #21. archive.org's search gateway signals rejected queries — including `q` over ~2,000 chars — as **HTTP 200** with `{"error": "[UNSUPPORTED_VALUE] …"}` and no `response` block. IAKit turned that into an opaque `DecodingError.keyNotFound`; consumers couldn't tell a rejected query from a schema change. This caused LiveMusicArchive/LiveMusicArchive#556.

## Changes

- **`InternetArchiveError.apiError(message:)`** — `makeRequest` probes a failed decode for the error envelope and surfaces the gateway's message as a semantic, `Equatable`, `LocalizedError` case. Probe order means the happy path pays nothing, and valid-JSON-wrong-shape bodies without a top-level `error` key still surface the original `DecodingError`.
- **Query-length guard** — `URLGenerator.generateSearchUrl` now `os_log`s and `assertionFailure`s (debug only; the request still goes out) when assembled `q` exceeds the new public constant `recommendedMaxQueryLength` (1,800 — headroom under the measured ~1,940/2,071 accept/reject boundary). Clients batching values into one clause can chunk against the constant.
- **Package.swift: macOS floor 10.13 → 10.15** — the async/await code already required 10.15, so the package hasn't compiled for macOS since async was introduced; this unbreaks `swift test` on Mac. No effect on iOS consumers (floor stays v13).

## Tests

- New `APIErrorTests`: error-envelope search → `.apiError` with message; wrong-shape body without `error` key stays a `DecodingError`; length-predicate bounds; `LocalizedError` message.
- Full suite green via `swift test` (includes the live-network tests).

After merge: tag **1.0.3** so LiveMusicArchive can bump its pin (tracked in LiveMusicArchive/LiveMusicArchive#559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
