### PR TITLE
Fix Review.reviewer_itemname never decoding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,7 @@ excluded:
   - InternetArchiveKitExample
 identifier_name:
   excluded:
-    - reviewer_itemname  # matches the Internet Archive API field name
+    - reviewer_itemname  # deprecated alias for reviewerItemname, kept for source compatibility
 type_name:
   min_length: 3
   max_length:

--- a/InternetArchiveKit/Models/Review.swift
+++ b/InternetArchiveKit/Models/Review.swift
@@ -21,7 +21,6 @@ extension InternetArchive {
     public let stars: ModelField<IADouble>?
 
     @available(*, deprecated, renamed: "reviewerItemname")
-    // swiftlint:disable:next identifier_name
     public var reviewer_itemname: String? { reviewerItemname }
 
     public init(
@@ -49,7 +48,6 @@ extension InternetArchive {
       reviewbody: ModelField<IAString>? = nil,
       reviewtitle: String? = nil,
       reviewer: String? = nil,
-      // swiftlint:disable:next identifier_name
       reviewer_itemname: String?,
       reviewdate: ModelField<IADate>? = nil,
       createdate: ModelField<IADate>? = nil,

--- a/InternetArchiveKit/Models/Review.swift
+++ b/InternetArchiveKit/Models/Review.swift
@@ -20,6 +20,10 @@ extension InternetArchive {
     public let createdate: ModelField<IADate>?
     public let stars: ModelField<IADouble>?
 
+    @available(*, deprecated, renamed: "reviewerItemname")
+    // swiftlint:disable:next identifier_name
+    public var reviewer_itemname: String? { reviewerItemname }
+
     public init(
       reviewbody: ModelField<IAString>? = nil,
       reviewtitle: String? = nil,
@@ -36,6 +40,30 @@ extension InternetArchive {
       self.reviewdate = reviewdate
       self.createdate = createdate
       self.stars = stars
+    }
+
+    // `reviewer_itemname` intentionally has no default value: if both inits
+    // were callable with zero arguments, `Review()` would be ambiguous.
+    @available(*, deprecated, message: "Use init(reviewerItemname:) instead of init(reviewer_itemname:)")
+    public init(
+      reviewbody: ModelField<IAString>? = nil,
+      reviewtitle: String? = nil,
+      reviewer: String? = nil,
+      // swiftlint:disable:next identifier_name
+      reviewer_itemname: String?,
+      reviewdate: ModelField<IADate>? = nil,
+      createdate: ModelField<IADate>? = nil,
+      stars: ModelField<IADouble>? = nil
+    ) {
+      self.init(
+        reviewbody: reviewbody,
+        reviewtitle: reviewtitle,
+        reviewer: reviewer,
+        reviewerItemname: reviewer_itemname,
+        reviewdate: reviewdate,
+        createdate: createdate,
+        stars: stars
+      )
     }
   }
 }

--- a/InternetArchiveKit/Models/Review.swift
+++ b/InternetArchiveKit/Models/Review.swift
@@ -15,7 +15,7 @@ extension InternetArchive {
     public let reviewbody: ModelField<IAString>?
     public let reviewtitle: String?
     public let reviewer: String?
-    public let reviewer_itemname: String?
+    public let reviewerItemname: String?
     public let reviewdate: ModelField<IADate>?
     public let createdate: ModelField<IADate>?
     public let stars: ModelField<IADouble>?
@@ -24,7 +24,7 @@ extension InternetArchive {
       reviewbody: ModelField<IAString>? = nil,
       reviewtitle: String? = nil,
       reviewer: String? = nil,
-      reviewer_itemname: String? = nil,
+      reviewerItemname: String? = nil,
       reviewdate: ModelField<IADate>? = nil,
       createdate: ModelField<IADate>? = nil,
       stars: ModelField<IADouble>? = nil
@@ -32,7 +32,7 @@ extension InternetArchive {
       self.reviewbody = reviewbody
       self.reviewtitle = reviewtitle
       self.reviewer = reviewer
-      self.reviewer_itemname = reviewer_itemname
+      self.reviewerItemname = reviewerItemname
       self.reviewdate = reviewdate
       self.createdate = createdate
       self.stars = stars

--- a/InternetArchiveKitTests/ReviewTests.swift
+++ b/InternetArchiveKitTests/ReviewTests.swift
@@ -1,0 +1,54 @@
+//
+//  ReviewTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 6/11/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+import ZippyJSON
+import InternetArchiveKit
+
+class ReviewTests: XCTestCase {
+
+  // Mirrors a review object from MockResponse/metadataResponse.json.
+  // `reviewer_itemname` is the only snake_case key the API returns for a
+  // review, so it only decodes through `.convertFromSnakeCase` if the Swift
+  // property is named `reviewerItemname`.
+  private let reviewJson = #"""
+  {
+    "reviewbody": "Stellar show. First set starts off with a nearly 14 minute Sugaree.",
+    "reviewtitle": "This Matrix is deliciously ludicrous!",
+    "reviewer": "HughMcQToo",
+    "reviewer_itemname": "@hughmcqtoo",
+    "reviewdate": "2017-12-11 18:56:28",
+    "createdate": "2017-12-11 18:56:28",
+    "stars": "5"
+  }
+  """#.data(using: .utf8)!
+
+  func testDecodesReviewerItemnameWithZippyJSON() throws {
+    // Same decoder configuration as InternetArchive.swift
+    let decoder = ZippyJSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+    let review = try decoder.decode(InternetArchive.Review.self, from: reviewJson)
+    XCTAssertEqual(review.reviewer, "HughMcQToo")
+    XCTAssertEqual(review.stars?.value, 5)
+    XCTAssertEqual(review.reviewerItemname, "@hughmcqtoo")
+  }
+
+  func testDecodesReviewerItemnameWithFoundationJSONDecoder() throws {
+    // ZippyJSONDecoder falls back to Foundation's JSONDecoder on unsupported
+    // platforms, so both decoders must agree.
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+    let review = try decoder.decode(InternetArchive.Review.self, from: reviewJson)
+    XCTAssertEqual(review.reviewer, "HughMcQToo")
+    XCTAssertEqual(review.stars?.value, 5)
+    XCTAssertEqual(review.reviewerItemname, "@hughmcqtoo")
+  }
+
+}

--- a/InternetArchiveKitTests/ReviewTests.swift
+++ b/InternetArchiveKitTests/ReviewTests.swift
@@ -51,4 +51,24 @@ class ReviewTests: XCTestCase {
     XCTAssertEqual(review.reviewerItemname, "@hughmcqtoo")
   }
 
+  // Deprecated context so the deprecated `reviewer_itemname` spellings can be
+  // exercised without compiler warnings.
+  @available(*, deprecated)
+  func testDeprecatedSnakeCaseSpellingsStillWork() throws {
+    let decoder = ZippyJSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+    let review = try decoder.decode(InternetArchive.Review.self, from: reviewJson)
+    XCTAssertEqual(review.reviewer_itemname, "@hughmcqtoo")
+
+    let constructed = InternetArchive.Review(reviewer_itemname: "@someuser")
+    XCTAssertEqual(constructed.reviewerItemname, "@someuser")
+    XCTAssertEqual(constructed.reviewer_itemname, "@someuser")
+
+    // Zero-argument and label-free calls must still resolve to the primary
+    // init — guards against overload ambiguity.
+    XCTAssertNil(InternetArchive.Review().reviewerItemname)
+    XCTAssertNil(InternetArchive.Review(reviewer: "someuser").reviewerItemname)
+  }
+
 }


### PR DESCRIPTION
## Summary

- `Review.reviewer_itemname` always decoded to `nil`: the decoder's `keyDecodingStrategy = .convertFromSnakeCase` converts the JSON key `reviewer_itemname` to `reviewerItemname` *before* CodingKeys matching, so the synthesized key for the snake_case Swift property never matched
- Renamed the property and public init label to `reviewerItemname`, matching the camelCase convention every other model already uses (`filesCount`, `itemSize`, `workableServers`)
- **Backwards compatible** — the old spellings keep working with deprecation warnings, so this ships as a minor release (1.1.0), no 2.0 needed:
  - deprecated computed alias `reviewer_itemname` forwards to `reviewerItemname` (with `renamed:` fix-it)
  - deprecated init overload preserves the old `reviewer_itemname:` parameter label; its parameter has no default so `Review()` stays unambiguous
- Added `ReviewTests.swift` with regression tests decoding a fixture mirroring `MockResponse/metadataResponse.json` under both `ZippyJSONDecoder` and Foundation's `JSONDecoder` (ZippyJSON falls back to Foundation on unsupported platforms, so both must agree), plus coverage for the deprecated spellings and init-overload resolution

Chose the rename over explicit `CodingKeys`: a `CodingKeys` fix would need the confusing post-conversion mapping `case reviewer_itemname = "reviewerItemname"`, and no model in the package uses `CodingKeys` today.

Closes #25

## Test plan

- [x] New `ReviewTests` failed before the fix (`nil` under both decoders), pass after
- [x] Deprecated `reviewer_itemname` property and `init(reviewer_itemname:)` overload covered by `testDeprecatedSnakeCaseSpellingsStillWork`
- [x] `swift test` — 70 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)