### PR TITLE
Update JJLISO8601DateFormatter 0.1.8 → 0.2.0

### DIFF
--- a/InternetArchiveKitTests/DateParserTests.swift
+++ b/InternetArchiveKitTests/DateParserTests.swift
@@ -1,0 +1,78 @@
+//
+//  DateParserTests.swift
+//  InternetArchiveKitTests
+//
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+@testable import InternetArchiveKit
+
+// DateParser is the production consumer of JJLISO8601DateFormatter. It walks a chain of
+// formatters — ISO8601 first, then a series of DateFormatter patterns — so that IA
+// metadata dates, which arrive in several shapes, all decode to a Date. These tests
+// drive the parser directly (no JSON layer) to pin every supported shape and the nil
+// cases, isolating the parser from the ModelField / ZippyJSON decode path.
+class DateParserTests: XCTestCase {
+  private let parser = DateParser.shared
+
+  // Mirrors DateParser's own fallback formatters (fixed-pattern, GMT) for comparisons.
+  private func gmtFormatter(_ format: String) -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter
+  }
+
+  // A full ISO8601 timestamp is handled by the JJL formatter at the head of the chain.
+  // Asserting the absolute epoch also proves ISO8601 wins over the looser yyyy-based
+  // patterns later in the chain (a year-only parse would yield 2018-01-01, not this).
+  func testParsesISO8601Zulu() {
+    XCTAssertEqual(parser.date(from: "2018-11-15T15:23:11Z"),
+                   Date(timeIntervalSince1970: 1542295391))
+  }
+
+  func testParsesISO8601WithTimeZoneOffset() {
+    let apple = ISO8601DateFormatter()
+    XCTAssertEqual(parser.date(from: "2018-11-15T15:23:11-02:30"),
+                   apple.date(from: "2018-11-15T15:23:11-02:30"))
+  }
+
+  func testParsesYearOnly() {
+    XCTAssertEqual(parser.date(from: "1957"),
+                   gmtFormatter("yyyy").date(from: "1957"))
+  }
+
+  func testParsesYearMonth() {
+    XCTAssertEqual(parser.date(from: "1987-07"),
+                   gmtFormatter("yyyy-MM").date(from: "1987-07"))
+  }
+
+  func testParsesYearMonthDay() {
+    XCTAssertEqual(parser.date(from: "1993-03-14"),
+                   gmtFormatter("yyyy-MM-dd").date(from: "1993-03-14"))
+  }
+
+  func testParsesSpaceSeparatedDateTime() {
+    XCTAssertEqual(parser.date(from: "2018-12-30 09:12:32"),
+                   gmtFormatter("yyyy-MM-dd HH:mm:ss").date(from: "2018-12-30 09:12:32"))
+  }
+
+  func testParsesBracketedYear() {
+    XCTAssertEqual(parser.date(from: "[1968]"),
+                   gmtFormatter("'['yyyy']'").date(from: "[1968]"))
+  }
+
+  func testParsesCircaYear() {
+    XCTAssertEqual(parser.date(from: "c.a. 1973"),
+                   gmtFormatter("'c.a.' yyyy").date(from: "c.a. 1973"))
+  }
+
+  func testReturnsNilForGarbage() {
+    XCTAssertNil(parser.date(from: "baddate"))
+  }
+
+  func testReturnsNilForEmptyString() {
+    XCTAssertNil(parser.date(from: ""))
+  }
+}

--- a/InternetArchiveKitTests/JJLISO8601DateFormatterTests.swift
+++ b/InternetArchiveKitTests/JJLISO8601DateFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-//  FastISO8601DateFormatterTests.swift
+//  JJLISO8601DateFormatterTests.swift
 //  InternetArchiveKitTests
 //
 //  Created by Jason Buckner on 4/15/19.
@@ -10,12 +10,33 @@ import XCTest
 @testable import InternetArchiveKit
 import JJLISO8601DateFormatter
 
+// JJLISO8601DateFormatter is a faster, drop-in replacement for Foundation's
+// ISO8601DateFormatter. These tests pin its behavior to Apple's formatter in both
+// directions — String -> Date parsing and Date -> String formatting — so a dependency
+// bump can be validated as genuinely drop-in rather than assumed to be.
+//
+// JJL only supports the Gregorian calendar (instants on/after 1583), so all fixtures
+// use modern dates.
 class JJLISO8601DateFormatterTests: XCTestCase {
+
+  // A fixed instant reused across tests: 2018-11-15T15:23:11Z.
+  private let referenceEpoch: TimeInterval = 1542295391
+
+  // MARK: - Parsing (String -> Date)
+
   func testISODateParserCanParseGMT() {
     let isoDateParser = JJLISO8601DateFormatter()
     let isoFormatter = ISO8601DateFormatter()
     let comparisonISODate = isoFormatter.date(from: "2018-11-15T15:23:11Z")
     XCTAssertEqual(isoDateParser.date(from: "2018-11-15T15:23:11Z"), comparisonISODate)
+  }
+
+  // Pins the parsed instant to an absolute epoch, independent of Apple's formatter, so
+  // the contract holds even if both implementations were to drift together.
+  func testISODateParserParsesToExpectedEpoch() {
+    let isoDateParser = JJLISO8601DateFormatter()
+    XCTAssertEqual(isoDateParser.date(from: "2018-11-15T15:23:11Z"),
+                   Date(timeIntervalSince1970: referenceEpoch))
   }
 
   func testISODateParserHandlesTimezoneOffset() {
@@ -28,10 +49,122 @@ class JJLISO8601DateFormatterTests: XCTestCase {
     }
   }
 
+  // Broader offset matrix: zulu, zero offset, the issue's -07:00, half-hour offsets,
+  // and the extreme valid bounds.
+  func testISODateParserMatchesAppleAcrossOffsets() {
+    let appleFormatter = ISO8601DateFormatter()
+    let jjlFormatter = JJLISO8601DateFormatter()
+    let offsets = ["Z", "+00:00", "-07:00", "+05:30", "-12:00", "+14:00"]
+    for offset in offsets {
+      let string = "2018-11-15T15:23:11\(offset)"
+      let comparisonDate = appleFormatter.date(from: string)
+      XCTAssertNotNil(comparisonDate, "Apple failed to parse \(string)")
+      XCTAssertEqual(jjlFormatter.date(from: string), comparisonDate, "mismatch for \(string)")
+    }
+  }
+
+  func testISODateParserHandlesFractionalSeconds() {
+    let appleFormatter = ISO8601DateFormatter()
+    appleFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let jjlFormatter = JJLISO8601DateFormatter()
+    jjlFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let dates = ["2018-11-15T15:23:11.123Z", "2018-11-15T15:23:11.123-07:00"]
+    for date in dates {
+      let comparisonDate = appleFormatter.date(from: date)
+      XCTAssertNotNil(comparisonDate)
+      XCTAssertEqual(jjlFormatter.date(from: date), comparisonDate)
+    }
+  }
+
+  func testISODateParserHandlesLeapDay() {
+    let appleFormatter = ISO8601DateFormatter()
+    let jjlFormatter = JJLISO8601DateFormatter()
+    let leapDay = "2020-02-29T23:59:59Z"
+    let comparisonDate = appleFormatter.date(from: leapDay)
+    XCTAssertNotNil(comparisonDate)
+    XCTAssertEqual(jjlFormatter.date(from: leapDay), comparisonDate)
+  }
+
   func testISODateParserGMTFormat() {
     let isoDateParser = JJLISO8601DateFormatter()
     XCTAssertNil(isoDateParser.date(from: "ABCD-AS-BATBA:AS:AS-AS:AS"))
   }
+
+  // Malformed and incomplete inputs must behave exactly as Apple's formatter does —
+  // all nil under the default .withInternetDateTime options.
+  func testISODateParserMatchesAppleOnMalformedInput() {
+    let appleFormatter = ISO8601DateFormatter()
+    let jjlFormatter = JJLISO8601DateFormatter()
+    let inputs = ["", "not a date", "2018", "2018-11-15", "15:23:11Z", "2018/11/15 15:23:11"]
+    for input in inputs {
+      let comparisonDate = appleFormatter.date(from: input)
+      XCTAssertNil(comparisonDate, "Apple unexpectedly parsed '\(input)'")
+      XCTAssertEqual(jjlFormatter.date(from: input), comparisonDate, "mismatch for '\(input)'")
+    }
+  }
+
+  // MARK: - Formatting (Date -> String), the 0.2.0 fast path
+
+  func testStringFromDateMatchesAppleDefaultOptions() {
+    let date = Date(timeIntervalSince1970: referenceEpoch)
+    assertStringEquivalent(date: date, options: .withInternetDateTime)
+  }
+
+  func testStringFromDateMatchesAppleWithFractionalSeconds() {
+    let date = Date(timeIntervalSince1970: referenceEpoch + 0.123)
+    assertStringEquivalent(date: date, options: [.withInternetDateTime, .withFractionalSeconds])
+  }
+
+  func testStringFromDateMatchesAppleAcrossFormatOptions() {
+    let appleParser = ISO8601DateFormatter()
+    let dates = [
+      appleParser.date(from: "2018-11-15T15:23:11Z")!,
+      appleParser.date(from: "2000-01-01T00:00:00Z")!,
+      appleParser.date(from: "2020-02-29T23:59:59Z")!
+    ]
+    let optionSets: [ISO8601DateFormatter.Options] = [
+      .withInternetDateTime,
+      .withFullDate,
+      .withFullTime,
+      [.withFullDate, .withFullTime, .withSpaceBetweenDateAndTime]
+    ]
+    for date in dates {
+      for options in optionSets {
+        assertStringEquivalent(date: date, options: options)
+      }
+    }
+  }
+
+  func testStringFromDateRespectsTimeZone() {
+    let date = Date(timeIntervalSince1970: referenceEpoch)
+    let zones = [
+      TimeZone(secondsFromGMT: 0)!,
+      TimeZone(secondsFromGMT: -7 * 3600)!,
+      TimeZone(secondsFromGMT: 5 * 3600 + 1800)!
+    ]
+    for zone in zones {
+      assertStringEquivalent(date: date, options: .withInternetDateTime, timeZone: zone)
+    }
+  }
+
+  func testStaticStringFromDateMatchesApple() {
+    let date = Date(timeIntervalSince1970: referenceEpoch)
+    let zone = TimeZone(secondsFromGMT: 0)!
+    let jjlString = JJLISO8601DateFormatter.string(from: date, timeZone: zone, formatOptions: .withInternetDateTime)
+    let appleString = ISO8601DateFormatter.string(from: date, timeZone: zone, formatOptions: .withInternetDateTime)
+    XCTAssertEqual(jjlString, appleString)
+  }
+
+  // MARK: - Round trip
+
+  func testDateToStringToDateRoundTrip() {
+    let formatter = JJLISO8601DateFormatter()
+    let original = Date(timeIntervalSince1970: referenceEpoch) // whole seconds -> exact
+    let string = formatter.string(from: original)
+    XCTAssertEqual(formatter.date(from: string), original)
+  }
+
+  // MARK: - Performance & concurrency
 
   func testISODateParsePerformance() {
     let isoDateParser = JJLISO8601DateFormatter()
@@ -73,5 +206,26 @@ class JJLISO8601DateFormatterTests: XCTestCase {
       }
     }
     waitForExpectations(timeout: 20, handler: nil)
+  }
+
+  // MARK: - Helpers
+
+  // Asserts JJL and Apple produce identical strings for the same date/options/zone.
+  // String equality sidesteps floating-point precision concerns: both formatters
+  // operate on the same Date and round identically.
+  private func assertStringEquivalent(
+    date: Date,
+    options: ISO8601DateFormatter.Options,
+    timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    let apple = ISO8601DateFormatter()
+    apple.formatOptions = options
+    apple.timeZone = timeZone
+    let jjl = JJLISO8601DateFormatter()
+    jjl.formatOptions = options
+    jjl.timeZone = timeZone
+    XCTAssertEqual(jjl.string(from: date), apple.string(from: date), file: file, line: line)
   }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/michaeleisel/JJLISO8601DateFormatter",
       "state" : {
-        "revision" : "741a9e45db01148a8ac60c5e12f7c978181a22d3",
-        "version" : "0.1.8"
+        "revision" : "50d5ea26ffd3f82e3db8516d939d80b745e168cf",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/michaeleisel/ZippyJSON", .upToNextMajor(from: "1.2.4")),
-    .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.1.8")),
+    .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.2.0")),
     .package(url: "https://github.com/azsn/URLSessionMock", .upToNextMajor(from: "0.1.0")),
   ],
   targets: [


### PR DESCRIPTION
Closes #30.

Bumps **JJLISO8601DateFormatter** 0.1.8 → 0.2.0 (Swift rewrite + new Date→String fast path).

- `Package.resolved` → 0.2.0; constraint floor raised to `.upToNextMajor(from: "0.2.0")` to document the tested minimum. The existing constraint already permitted 0.2.0, so no functional `Package.swift` change was required.
- `DateParser.swift` untouched — runtime behavior unchanged.
- Tests expanded **70 → 91**, all green.

### Why the extra tests
A 0.x **minor** is the conventional breaking-change lever, and 0.2.0 is a formatter rewrite whose headline **Date→String** path had **zero** prior coverage (the old suite tested parsing only). New tests pin JJL output to Apple's `ISO8601DateFormatter` in both directions:

- `JJLISO8601DateFormatterTests` (5 → 16): Date→String formatting matrix, OS-independent epoch anchor, wider offset matrix (`Z`/`+00:00`/`-07:00`/`+05:30`/`-12:00`/`+14:00`), fractional seconds, leap day, malformed-input equivalence, round-trip.
- `DateParserTests` (new, 10): direct unit tests of the `DateParser` fallback chain (ISO8601 + the year/bracket/circa/datetime patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)