### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .build
+.claude


### PR DESCRIPTION
Adds `.claude` to `.gitignore` so the local Claude Code directory (git worktrees and settings) isn't tracked.

Nothing under `.claude` was previously committed, so no `git rm --cached` was needed — verified with `git check-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
