### PR TITLE
Add Scrape API support for reading past the 10,000-result ceiling

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -167,6 +167,51 @@ public class InternetArchive: InternetArchiveProtocol {
   }
 
   /** @inheritdoc */
+  public func scrapeTotal(
+    query: InternetArchiveURLStringProtocol
+  ) async -> Result<Int, Error> {
+    guard
+      let scrapeUrl: URL = urlGenerator.generateScrapeUrl(
+        query: query,
+        fields: [],
+        sortFields: [],
+        pagination: nil,
+        // `total_only=true` returns the match count with no items
+        additionalQueryParams: [
+          URLQueryItem(name: "total_only", value: "true")
+        ]
+      )
+    else {
+      os_log(
+        .error,
+        log: log,
+        "Error generating scrapeTotal url: %@",
+        query.asURLString ?? "Unknown query.asURLString"
+      )
+      return .failure(InternetArchiveError.invalidUrl)
+    }
+
+    let result: Result<ScrapeResponse, Error> = await makeRequest(url: scrapeUrl)
+    return result.map { $0.total }
+  }
+
+  /** @inheritdoc */
+  public func scrapeTotal(
+    query: InternetArchiveURLStringProtocol,
+    completion: @escaping (Int?, Error?) -> Void
+  ) {
+    Task {
+      let result: Result<Int, Error> = await scrapeTotal(query: query)
+      switch result {
+      case .success(let total):
+        completion(total, nil)
+      case .failure(let error):
+        completion(nil, error)
+      }
+    }
+  }
+
+  /** @inheritdoc */
   public func itemDetail(identifier: String) async -> Result<Item, Error> {
     guard
       let metadataUrl: URL = urlGenerator.generateMetadataUrl(

--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -121,6 +121,14 @@ public class InternetArchive: InternetArchiveProtocol {
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
     pagination: ScrapePagination?
   ) async -> Result<ScrapeResponse, Error> {
+    if URLGenerator.scrapeSortMisplacesIdentifier(sortFields ?? []) {
+      return .failure(
+        InternetArchiveError.invalidSortFields(
+          message: "'identifier' must be the last sort field"
+        )
+      )
+    }
+
     guard
       let scrapeUrl: URL = urlGenerator.generateScrapeUrl(
         query: query,

--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -119,14 +119,14 @@ public class InternetArchive: InternetArchiveProtocol {
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    cursor: String?
+    pagination: ScrapePagination?
   ) async -> Result<ScrapeResponse, Error> {
     guard
       let scrapeUrl: URL = urlGenerator.generateScrapeUrl(
         query: query,
         fields: fields ?? [],
         sortFields: sortFields ?? [],
-        cursor: cursor,
+        pagination: pagination,
         additionalQueryParams: []
       )
     else {
@@ -147,7 +147,7 @@ public class InternetArchive: InternetArchiveProtocol {
     query: InternetArchiveURLStringProtocol,
     fields: [String]? = nil,
     sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
-    cursor: String? = nil,
+    pagination: ScrapePagination? = nil,
     completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
   ) {
     Task {
@@ -155,7 +155,7 @@ public class InternetArchive: InternetArchiveProtocol {
         query: query,
         fields: fields,
         sortFields: sortFields,
-        cursor: cursor
+        pagination: pagination
       )
       switch results {
       case .success(let response):

--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -115,6 +115,58 @@ public class InternetArchive: InternetArchiveProtocol {
   }
 
   /** @inheritdoc */
+  public func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]?,
+    sortFields: [InternetArchiveURLQueryItemProtocol]?,
+    cursor: String?
+  ) async -> Result<ScrapeResponse, Error> {
+    guard
+      let scrapeUrl: URL = urlGenerator.generateScrapeUrl(
+        query: query,
+        fields: fields ?? [],
+        sortFields: sortFields ?? [],
+        cursor: cursor,
+        additionalQueryParams: []
+      )
+    else {
+      os_log(
+        .error,
+        log: log,
+        "Error generating scrape url: %@",
+        query.asURLString ?? "Unknown query.asURLString"
+      )
+      return .failure(InternetArchiveError.invalidUrl)
+    }
+
+    return await makeRequest(url: scrapeUrl)
+  }
+
+  /** @inheritdoc */
+  public func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]? = nil,
+    sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
+    cursor: String? = nil,
+    completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
+  ) {
+    Task {
+      let results: Result<ScrapeResponse, Error> = await scrape(
+        query: query,
+        fields: fields,
+        sortFields: sortFields,
+        cursor: cursor
+      )
+      switch results {
+      case .success(let response):
+        completion(response, nil)
+      case .failure(let error):
+        completion(nil, error)
+      }
+    }
+  }
+
+  /** @inheritdoc */
   public func itemDetail(identifier: String) async -> Result<Item, Error> {
     guard
       let metadataUrl: URL = urlGenerator.generateMetadataUrl(

--- a/InternetArchiveKit/InternetArchiveErrors.swift
+++ b/InternetArchiveKit/InternetArchiveErrors.swift
@@ -22,6 +22,12 @@ extension InternetArchive {
     /// `{"error": "[UNSUPPORTED_VALUE] …"}` with no `response` block.
     /// `message` carries the API's error string.
     case apiError(message: String)
+
+    /// A `scrape()` request was given sort fields archive.org would reject,
+    /// caught client-side before the request is sent. archive.org requires
+    /// `identifier`, if it appears in a scrape sort, to be the last sort field.
+    /// `message` explains what to fix.
+    case invalidSortFields(message: String)
   }
 }
 
@@ -32,6 +38,8 @@ extension InternetArchive.InternetArchiveError: LocalizedError {
       return "Invalid URL"
     case .apiError(let message):
       return "Internet Archive API error: \(message)"
+    case .invalidSortFields(let message):
+      return "Invalid sort fields: \(message)"
     }
   }
 }

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -79,8 +79,9 @@ public protocol InternetArchiveProtocol {
 
    The Scrape API walks through an entire result set with a `cursor`, so it can
    read past the 10,000-result ceiling that `search()` is bound by. Start with
-   `cursor: nil`, then pass each `ScrapeResponse.cursor` back in to fetch the
-   next batch until `cursor` comes back `nil`. archive.org fixes the batch size
+   `pagination: nil` (or `.count(n)` to size the first batch), then pass
+   `.cursor(response.cursor)` back in to fetch each next batch until the
+   response's `cursor` comes back `nil`. archive.org fixes the cursor batch size
    server-side (~5,000 items).
 
    - parameters:
@@ -89,14 +90,14 @@ public protocol InternetArchiveProtocol {
    which returns all metadata fields
    - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
    on, to be the last sort field, and caps custom-sorted paging at 10,000 results
-   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - pagination: `.cursor` to resume, `.count` to size a one-shot or first batch, or `nil` for the default first batch
    - returns: Result<InternetArchive.ScrapeResponse, Error>
    */
   func scrape(
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    cursor: String?
+    pagination: InternetArchive.ScrapePagination?
   ) async throws -> InternetArchive.ScrapeResponse
 
   /**
@@ -108,14 +109,14 @@ public protocol InternetArchiveProtocol {
    which returns all metadata fields
    - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
    on, to be the last sort field, and caps custom-sorted paging at 10,000 results
-   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - pagination: `.cursor` to resume, `.count` to size a one-shot or first batch, or `nil` for the default first batch
    - returns: Result<InternetArchive.ScrapeResponse, Error>
    */
   func scrape(
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    cursor: String?
+    pagination: InternetArchive.ScrapePagination?
   ) async -> Result<InternetArchive.ScrapeResponse, Error>
 
   /**
@@ -127,14 +128,14 @@ public protocol InternetArchiveProtocol {
    which returns all metadata fields
    - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
    on, to be the last sort field, and caps custom-sorted paging at 10,000 results
-   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - pagination: `.cursor` to resume, `.count` to size a one-shot or first batch, or `nil` for the default first batch
    - completion: Returns optional `InternetArchive.ScrapeResponse` and `Error` objects
    */
   func scrape(
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    cursor: String?,
+    pagination: InternetArchive.ScrapePagination?,
     completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
   )
 
@@ -191,7 +192,7 @@ public protocol InternetArchiveURLGeneratorProtocol {
     query: InternetArchiveURLStringProtocol,
     fields: [String],
     sortFields: [InternetArchiveURLQueryItemProtocol],
-    cursor: String?,
+    pagination: InternetArchive.ScrapePagination?,
     additionalQueryParams: [URLQueryItem]
   ) -> URL?
 }
@@ -238,13 +239,13 @@ extension InternetArchiveProtocol {
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    cursor: String?
+    pagination: InternetArchive.ScrapePagination?
   ) async throws -> InternetArchive.ScrapeResponse {
     let result: Result<InternetArchive.ScrapeResponse, Error> = await scrape(
       query: query,
       fields: fields,
       sortFields: sortFields,
-      cursor: cursor
+      pagination: pagination
     )
 
     switch result {

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -72,8 +72,72 @@ public protocol InternetArchiveProtocol {
   )
 
   /**
+   Scrape the Internet Archive
+
+   The Scrape API walks through an entire result set with a `cursor`, so it can
+   read past the 10,000-result ceiling that `search()` is bound by. Start with
+   `cursor: nil`, then pass each `ScrapeResponse.cursor` back in to fetch the
+   next batch until `cursor` comes back `nil`. archive.org fixes the batch size
+   server-side (~5,000 items).
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - fields: An array of strings specifying the metadata entries you want returned. The default is `nil`,
+   which returns all metadata fields
+   - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
+   on, to be the last sort field, and caps custom-sorted paging at 10,000 results
+   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - returns: Result<InternetArchive.ScrapeResponse, Error>
+   */
+  func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]?,
+    sortFields: [InternetArchiveURLQueryItemProtocol]?,
+    cursor: String?
+  ) async throws -> InternetArchive.ScrapeResponse
+
+  /**
+   Scrape the Internet Archive
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - fields: An array of strings specifying the metadata entries you want returned. The default is `nil`,
+   which returns all metadata fields
+   - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
+   on, to be the last sort field, and caps custom-sorted paging at 10,000 results
+   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - returns: Result<InternetArchive.ScrapeResponse, Error>
+   */
+  func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]?,
+    sortFields: [InternetArchiveURLQueryItemProtocol]?,
+    cursor: String?
+  ) async -> Result<InternetArchive.ScrapeResponse, Error>
+
+  /**
+   Scrape the Internet Archive
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - fields: An array of strings specifying the metadata entries you want returned. The default is `nil`,
+   which returns all metadata fields
+   - sortFields: The fields by which you want to sort the results. archive.org requires `identifier`, if sorted
+   on, to be the last sort field, and caps custom-sorted paging at 10,000 results
+   - cursor: The cursor from the previous batch, or `nil` for the first batch
+   - completion: Returns optional `InternetArchive.ScrapeResponse` and `Error` objects
+   */
+  func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]?,
+    sortFields: [InternetArchiveURLQueryItemProtocol]?,
+    cursor: String?,
+    completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
+  )
+
+  /**
    Fetch a single item from the Internet Archive
-  
+
    - parameters:
    - identifier: The item identifier
    - returns: Result<InternetArchive.Item, Error>
@@ -120,6 +184,13 @@ public protocol InternetArchiveURLGeneratorProtocol {
     sortFields: [InternetArchiveURLQueryItemProtocol],
     additionalQueryParams: [URLQueryItem]
   ) -> URL?
+  func generateScrapeUrl(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String],
+    sortFields: [InternetArchiveURLQueryItemProtocol],
+    cursor: String?,
+    additionalQueryParams: [URLQueryItem]
+  ) -> URL?
 }
 
 /// A protocol for abstracting URL search query strings
@@ -149,6 +220,28 @@ extension InternetArchiveProtocol {
       rows: rows,
       fields: fields,
       sortFields: sortFields
+    )
+
+    switch result {
+    case .success(let success):
+      return success
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  /** @inheritdoc */
+  public func scrape(
+    query: InternetArchiveURLStringProtocol,
+    fields: [String]?,
+    sortFields: [InternetArchiveURLQueryItemProtocol]?,
+    cursor: String?
+  ) async throws -> InternetArchive.ScrapeResponse {
+    let result: Result<InternetArchive.ScrapeResponse, Error> = await scrape(
+      query: query,
+      fields: fields,
+      sortFields: sortFields,
+      cursor: cursor
     )
 
     switch result {

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -12,7 +12,10 @@ import Foundation
 public protocol InternetArchiveProtocol {
   /**
    Search the Internet Archive
-  
+
+   This is for interactive, paged queries. archive.org caps paged search at the
+   10,000th result; to read an entire result set past that, use `scrape()`.
+
    - parameters:
    - query: The search query as an `InternetArchiveURLStringProtocol` object
    - page: The results pagination page number

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -140,6 +140,44 @@ public protocol InternetArchiveProtocol {
   )
 
   /**
+   Count the results of a Scrape API query
+
+   Returns the total number of matching items without fetching any of them
+   (the Scrape API's `total_only`). Cheaper than reading `total` off a regular
+   `scrape()` batch, which also pulls down a batch of items.
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - returns: Result<Int, Error>
+   */
+  func scrapeTotal(
+    query: InternetArchiveURLStringProtocol
+  ) async throws -> Int
+
+  /**
+   Count the results of a Scrape API query
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - returns: Result<Int, Error>
+   */
+  func scrapeTotal(
+    query: InternetArchiveURLStringProtocol
+  ) async -> Result<Int, Error>
+
+  /**
+   Count the results of a Scrape API query
+
+   - parameters:
+   - query: The search query as an `InternetArchiveURLStringProtocol` object
+   - completion: Returns an optional total count and `Error` object
+   */
+  func scrapeTotal(
+    query: InternetArchiveURLStringProtocol,
+    completion: @escaping (Int?, Error?) -> Void
+  )
+
+  /**
    Fetch a single item from the Internet Archive
 
    - parameters:
@@ -248,6 +286,19 @@ extension InternetArchiveProtocol {
       pagination: pagination
     )
 
+    switch result {
+    case .success(let success):
+      return success
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  /** @inheritdoc */
+  public func scrapeTotal(
+    query: InternetArchiveURLStringProtocol
+  ) async throws -> Int {
+    let result: Result<Int, Error> = await scrapeTotal(query: query)
     switch result {
     case .success(let success):
       return success

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -311,3 +311,35 @@ extension InternetArchive {
     case desc
   }
 }
+
+// MARK: Scrape Pagination
+extension InternetArchive {
+  /**
+   How a `scrape()` request is positioned and sized.
+
+   archive.org's Scrape API accepts a `count` (batch size) **or** a `cursor`
+   (resume token), but not both — sending a `count` makes it ignore the `cursor`
+   and re-serve the first batch. This models that exclusivity so it can't be
+   expressed incorrectly. Pass `nil` for the first batch at the server's default
+   size (~5,000 items).
+
+   ### Example Usage:
+   ```
+   // a bounded one-shot pull of up to 500 items
+   await archive.scrape(query: query, pagination: .count(500))
+
+   // resume from a previous batch
+   await archive.scrape(query: query, pagination: .cursor(previous.cursor!))
+   ```
+   */
+  public enum ScrapePagination {
+    /// Return this many items (archive.org allows 100–10,000) in a single
+    /// batch. Use for a bounded one-shot pull, or as a smaller first page
+    /// before scrolling. `count` sizes only the batch it is on; continuing
+    /// with `.cursor` reverts to the server's default batch size.
+    case count(Int)
+    /// Resume after the given cursor (from a previous `ScrapeResponse`), at the
+    /// server's default batch size.
+    case cursor(String)
+  }
+}

--- a/InternetArchiveKit/InternetArchiveResponse.swift
+++ b/InternetArchiveKit/InternetArchiveResponse.swift
@@ -96,4 +96,42 @@ extension InternetArchive {
       self.start = start
     }
   }
+
+  /**
+   The top-level response from a Scrape API (`/services/search/v1/scrape`) request.
+
+   The Scrape API is built for exhaustively exporting a result set: it scrolls
+   forward with an opaque `cursor` rather than random-access `page` numbers, and
+   it can walk past the 10,000-result ceiling that `search()` is bound by. Pass
+   `cursor` back into the next `scrape()` call to continue where this batch left
+   off; when `cursor` comes back `nil` the end of the result set has been reached.
+   */
+  public struct ScrapeResponse: Decodable {
+    /// The items in this batch. These are the same `ItemMetadata` documents
+    /// `search()` returns in `Response.docs`.
+    public let items: [ItemMetadata]
+    /// The number of items in this batch (`items.count`).
+    public let count: Int
+    /// The total number of items matching the query across every batch.
+    public let total: Int
+    /// The cursor to pass to the next `scrape()` call to fetch the following
+    /// batch. `nil` on the final batch, signalling the end of the result set.
+    public let cursor: String?
+    /// The cursor for the preceding batch, present from the second batch onward.
+    public let previous: String?
+
+    public init(
+      items: [ItemMetadata],
+      count: Int,
+      total: Int,
+      cursor: String? = nil,
+      previous: String? = nil
+    ) {
+      self.items = items
+      self.count = count
+      self.total = total
+      self.cursor = cursor
+      self.previous = previous
+    }
+  }
 }

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -96,6 +96,74 @@ extension InternetArchive {
       return urlComponents.url
     }
 
+    /**
+     Generate a Scrape API (`/services/search/v1/scrape`) url.
+
+     The Scrape API scrolls through an entire result set with a `cursor` instead
+     of `page`/`rows`, so it can read past the 10,000-result ceiling that
+     `generateSearchUrl` is bound by. Omit `cursor` for the first batch, then
+     pass the `cursor` from each `ScrapeResponse` to fetch the next; archive.org
+     fixes the batch size server-side (~5,000 items) and drops `cursor` from the
+     final batch.
+
+     Note: archive.org ignores `cursor` if a `count` is also sent, silently
+     re-returning the first batch, so this deliberately exposes no `count` and
+     paginates by cursor alone.
+
+     - parameters:
+       - query: The search query
+       - fields: The metadata fields to return
+       - sortFields: The fields to sort by. archive.org requires `identifier`,
+         if sorted on, to be the last sort field, and caps custom-sorted paging
+         at 10,000 results.
+       - cursor: The cursor from the previous batch, or `nil` for the first
+       - additionalQueryParams: Any extra query items to append
+
+     - returns: Optional scrape `URL`
+     */
+    public func generateScrapeUrl(
+      query: InternetArchiveURLStringProtocol,
+      fields: [String],
+      sortFields: [InternetArchiveURLQueryItemProtocol],
+      cursor: String?,
+      additionalQueryParams: [URLQueryItem]
+    ) -> URL? {
+      warnIfQueryExceedsRecommendedLength(query.asURLString)
+
+      var params: [URLQueryItem] = [
+        URLQueryItem(name: "q", value: query.asURLString)
+      ]
+
+      // The Scrape API takes single comma-delimited `fields` and `sorts`
+      // parameters rather than the repeated `fl[]`/`sort[]` items that
+      // advancedsearch.php uses.
+      if !fields.isEmpty {
+        params.append(
+          URLQueryItem(name: "fields", value: fields.joined(separator: ","))
+        )
+      }
+
+      // `SortField.asQueryItem` already formats each value as
+      // "<field> <direction>", so reuse those values and join them.
+      let sortValues: [String] = sortFields.compactMap { $0.asQueryItem.value }
+      if !sortValues.isEmpty {
+        params.append(
+          URLQueryItem(name: "sorts", value: sortValues.joined(separator: ","))
+        )
+      }
+
+      if let cursor = cursor {
+        params.append(URLQueryItem(name: "cursor", value: cursor))
+      }
+
+      params += additionalQueryParams
+
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/services/search/v1/scrape"
+      urlComponents.queryItems = params
+      return urlComponents.url
+    }
+
     private func getBaseUrlComponents() -> URLComponents {
       var urlComponents: URLComponents = URLComponents()
       urlComponents.scheme = scheme

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -183,6 +183,25 @@ extension InternetArchive {
       (queryString?.count ?? 0) > recommendedMaxQueryLength
     }
 
+    /// `true` when a scrape `sorts` lists `identifier` somewhere other than the
+    /// final position. archive.org rejects that (`identifier`, if present, must
+    /// be the last sort key); `identifier` alone or last is fine. Split out as a
+    /// static predicate so it is testable without a request — `scrape()` turns a
+    /// `true` here into `InternetArchiveError.invalidSortFields` before sending.
+    static func scrapeSortMisplacesIdentifier(
+      _ sortFields: [InternetArchiveURLQueryItemProtocol]
+    ) -> Bool {
+      // `SortField.asQueryItem` formats each value as "<field> <direction>", so
+      // the field name is the value's first whitespace-delimited token.
+      let fieldNames: [String] = sortFields.map {
+        String($0.asQueryItem.value?.split(separator: " ").first ?? "")
+      }
+      guard let identifierIndex = fieldNames.firstIndex(of: "identifier") else {
+        return false
+      }
+      return identifierIndex != fieldNames.count - 1
+    }
+
     /// The request is still sent — the gateway's `{"error": …}` body comes
     /// back as `InternetArchiveError.apiError` — but an oversized query is
     /// almost certainly a batching bug, so fail loudly in development.

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -101,14 +101,11 @@ extension InternetArchive {
 
      The Scrape API scrolls through an entire result set with a `cursor` instead
      of `page`/`rows`, so it can read past the 10,000-result ceiling that
-     `generateSearchUrl` is bound by. Omit `cursor` for the first batch, then
-     pass the `cursor` from each `ScrapeResponse` to fetch the next; archive.org
-     fixes the batch size server-side (~5,000 items) and drops `cursor` from the
-     final batch.
-
-     Note: archive.org ignores `cursor` if a `count` is also sent, silently
-     re-returning the first batch, so this deliberately exposes no `count` and
-     paginates by cursor alone.
+     `generateSearchUrl` is bound by. `pagination` is `.cursor` to resume or
+     `.count` to size a batch; archive.org ignores `cursor` when a `count` is
+     also sent, so the two are modelled as one mutually-exclusive value. Pass
+     `nil` for the first batch at the server default size (~5,000 items); the
+     response drops its `cursor` on the final batch.
 
      - parameters:
        - query: The search query
@@ -116,7 +113,8 @@ extension InternetArchive {
        - sortFields: The fields to sort by. archive.org requires `identifier`,
          if sorted on, to be the last sort field, and caps custom-sorted paging
          at 10,000 results.
-       - cursor: The cursor from the previous batch, or `nil` for the first
+       - pagination: `.cursor` to resume a scroll, `.count` to size a one-shot
+         or first batch, or `nil` for the default first batch
        - additionalQueryParams: Any extra query items to append
 
      - returns: Optional scrape `URL`
@@ -125,7 +123,7 @@ extension InternetArchive {
       query: InternetArchiveURLStringProtocol,
       fields: [String],
       sortFields: [InternetArchiveURLQueryItemProtocol],
-      cursor: String?,
+      pagination: InternetArchive.ScrapePagination?,
       additionalQueryParams: [URLQueryItem]
     ) -> URL? {
       warnIfQueryExceedsRecommendedLength(query.asURLString)
@@ -152,8 +150,15 @@ extension InternetArchive {
         )
       }
 
-      if let cursor = cursor {
-        params.append(URLQueryItem(name: "cursor", value: cursor))
+      // archive.org rejects `count` and `cursor` together, which is why
+      // `ScrapePagination` makes them mutually exclusive.
+      if let pagination = pagination {
+        switch pagination {
+        case .count(let count):
+          params.append(URLQueryItem(name: "count", value: "\(count)"))
+        case .cursor(let cursor):
+          params.append(URLQueryItem(name: "cursor", value: cursor))
+        }
       }
 
       params += additionalQueryParams

--- a/InternetArchiveKitExample.xcodeproj/project.pbxproj
+++ b/InternetArchiveKitExample.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		96AC727B219D2E6A007C7910 /* MusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AC727A219D2E6A007C7910 /* MusicPlayer.swift */; };
 		96BAF7CE219BC016004B512D /* AlbumExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BAF7CD219BC016004B512D /* AlbumExtensions.swift */; };
 		96BAF7D8219BD6FE004B512D /* Collection+InternetArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BAF7D7219BD6FE004B512D /* Collection+InternetArchive.swift */; };
+		9653CDC62770140000000002 /* ScrapeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9653CDC52770140000000001 /* ScrapeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -53,6 +54,7 @@
 		96AC727A219D2E6A007C7910 /* MusicPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayer.swift; sourceTree = "<group>"; };
 		96BAF7CD219BC016004B512D /* AlbumExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumExtensions.swift; sourceTree = "<group>"; };
 		96BAF7D7219BD6FE004B512D /* Collection+InternetArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+InternetArchive.swift"; sourceTree = "<group>"; };
+		9653CDC52770140000000001 /* ScrapeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrapeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +74,7 @@
 			children = (
 				9669B0232197B91200E7CE2A /* AppDelegate.swift */,
 				9669B0252197B91200E7CE2A /* EtreeCollectionViewController.swift */,
+				9653CDC52770140000000001 /* ScrapeViewController.swift */,
 				96AC7278219C64F1007C7910 /* Debouncer.swift */,
 				96BAF7CF219BC9C7004B512D /* ArtistDetail */,
 				96BAF7D0219BC9DD004B512D /* AlbumDetail */,
@@ -183,6 +186,9 @@
 				Base,
 			);
 			mainGroup = 96ECE0CE21913AE100A0C8A6;
+			packageReferences = (
+				9653CDC4277013A0006D0C5C /* XCLocalSwiftPackageReference "." */,
+			);
 			productRefGroup = 96ECE0D921913AE100A0C8A6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -218,6 +224,7 @@
 				9694E66A219A6F3E00F6D26B /* ConcertsDataSource.swift in Sources */,
 				9669B0282197B91200E7CE2A /* ArtistDetailViewController.swift in Sources */,
 				9669B0262197B91200E7CE2A /* EtreeCollectionViewController.swift in Sources */,
+				9653CDC62770140000000002 /* ScrapeViewController.swift in Sources */,
 				96AC727B219D2E6A007C7910 /* MusicPlayer.swift in Sources */,
 				9669B0242197B91200E7CE2A /* AppDelegate.swift in Sources */,
 			);
@@ -432,9 +439,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		9653CDC4277013A0006D0C5C /* XCLocalSwiftPackageReference "." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ".";
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		9653CDC1277012B6006D0C5C /* InternetArchiveKit */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 9653CDC4277013A0006D0C5C /* XCLocalSwiftPackageReference "." */;
 			productName = InternetArchiveKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/InternetArchiveKitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InternetArchiveKitExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,52 +1,33 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AsyncCompatibilityKit",
-        "repositoryURL": "https://github.com/JohnSundell/AsyncCompatibilityKit",
-        "state": {
-          "branch": null,
-          "revision": "bedef0457c31ef0236e0e92ad2e96c57bd3d8606",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "JJLISO8601DateFormatter",
-        "repositoryURL": "https://github.com/michaeleisel/JJLISO8601DateFormatter",
-        "state": {
-          "branch": null,
-          "revision": "99fadf2e6425a0f827b1b485ea60bc2b7ecdd22c",
-          "version": "0.1.4"
-        }
-      },
-      {
-        "package": "URLSessionMock",
-        "repositoryURL": "https://github.com/azsn/URLSessionMock",
-        "state": {
-          "branch": null,
-          "revision": "128e48ecdea3508b1264d31443a83e718caa8f7e",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "ZippyJSON",
-        "repositoryURL": "https://github.com/michaeleisel/ZippyJSON",
-        "state": {
-          "branch": null,
-          "revision": "1ab389998592d038a60a3ca71aa7554d0e84ab4a",
-          "version": "1.2.4"
-        }
-      },
-      {
-        "package": "ZippyJSONCFamily",
-        "repositoryURL": "https://github.com/michaeleisel/ZippyJSONCFamily",
-        "state": {
-          "branch": null,
-          "revision": "c55123b23f0faa898b22bf1b967e72a2df51fdb4",
-          "version": "1.2.4"
-        }
+  "originHash" : "94303fba8394da74f09b0bf6a9c0bbed604113c92f59e5cf00b644531aacb92f",
+  "pins" : [
+    {
+      "identity" : "jjliso8601dateformatter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/michaeleisel/JJLISO8601DateFormatter",
+      "state" : {
+        "revision" : "50d5ea26ffd3f82e3db8516d939d80b745e168cf",
+        "version" : "0.2.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "zippyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/michaeleisel/ZippyJSON",
+      "state" : {
+        "revision" : "1ab389998592d038a60a3ca71aa7554d0e84ab4a",
+        "version" : "1.2.4"
+      }
+    },
+    {
+      "identity" : "zippyjsoncfamily",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/michaeleisel/ZippyJSONCFamily",
+      "state" : {
+        "revision" : "c55123b23f0faa898b22bf1b967e72a2df51fdb4",
+        "version" : "1.2.4"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/InternetArchiveKitExample/EtreeCollectionViewController.swift
+++ b/InternetArchiveKitExample/EtreeCollectionViewController.swift
@@ -32,6 +32,9 @@ class EtreeCollectionViewController: UITableViewController {
     navigationItem.searchController = searchController
     definesPresentationContext = true
 
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "Scrape", style: .plain, target: self, action: #selector(showScrapeDemo))
+
     // Setup the Scope Bar
 //    searchController.searchBar.scopeButtonTitles = ["All", "Chocolate", "Hard", "Other"]
     searchController.searchBar.delegate = self
@@ -50,6 +53,10 @@ class EtreeCollectionViewController: UITableViewController {
           self.tableView.reloadData()
         }
     })
+  }
+
+  @objc private func showScrapeDemo() {
+    navigationController?.pushViewController(ScrapeViewController(), animated: true)
   }
 
   override func viewWillAppear(_ animated: Bool) {

--- a/InternetArchiveKitExample/ScrapeViewController.swift
+++ b/InternetArchiveKitExample/ScrapeViewController.swift
@@ -1,0 +1,111 @@
+//
+//  ScrapeViewController.swift
+//  InternetArchiveKitExample
+//
+//  Created by Jason Buckner on 6/24/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import UIKit
+import InternetArchiveKit
+
+/// Demonstrates the Scrape API.
+///
+/// `scrapeTotal()` fetches the match count up front (shown in the title), then
+/// `scrape()`'s cursor pagination walks the entire `etree` collection in,
+/// appending each batch until the cursor runs out. Pull to refresh to re-run.
+class ScrapeViewController: UITableViewController {
+  private let internetArchive: InternetArchive = InternetArchive()
+  private let query: InternetArchive.Query = InternetArchive.Query(
+    clauses: ["collection": "etree", "mediatype": "collection"])
+
+  private var collections: [InternetArchive.ItemMetadata] = []
+  private var total: Int?
+  // `nil` requests the first batch at the server default size; a `.cursor`
+  // resumes where the previous batch left off.
+  private var nextPage: InternetArchive.ScrapePagination?
+  private var isLoading: Bool = false
+  private var reachedEnd: Bool = false
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    refreshControl = UIRefreshControl()
+    refreshControl?.addTarget(self, action: #selector(restart), for: .valueChanged)
+    restart()
+  }
+
+  @objc private func restart() {
+    collections = []
+    total = nil
+    nextPage = nil
+    reachedEnd = false
+    tableView.reloadData()
+    fetchTotal()
+    fetchNextBatch()
+  }
+
+  /// `scrapeTotal()` returns the match count without fetching any items.
+  private func fetchTotal() {
+    internetArchive.scrapeTotal(query: query) { [weak self] (total: Int?, _: Error?) in
+      DispatchQueue.main.async {
+        self?.total = total
+        self?.updateTitle()
+      }
+    }
+  }
+
+  /// Fetch the next batch, then chain to the one after it until the Scrape API
+  /// stops returning a cursor (which signals the end of the result set).
+  private func fetchNextBatch() {
+    guard !isLoading, !reachedEnd else { return }
+    isLoading = true
+
+    internetArchive.scrape(
+      query: query,
+      fields: ["identifier", "title"],
+      pagination: nextPage,
+      completion: { [weak self] (response: InternetArchive.ScrapeResponse?, _: Error?) in
+        DispatchQueue.main.async {
+          guard let self = self else { return }
+          self.isLoading = false
+          self.refreshControl?.endRefreshing()
+
+          guard let response = response else { return }
+          self.collections += response.items
+
+          if let cursor = response.cursor {
+            self.nextPage = .cursor(cursor)
+            self.fetchNextBatch()  // keep scrolling forward
+          } else {
+            self.reachedEnd = true
+          }
+
+          self.updateTitle()
+          self.tableView.reloadData()
+        }
+    })
+  }
+
+  private func updateTitle() {
+    if let total = total {
+      title = "etree \(collections.count)/\(total)"
+    } else {
+      title = "etree \(collections.count)"
+    }
+  }
+
+  // MARK: - Table view data source
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return collections.count
+  }
+
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: "cell")
+      ?? UITableViewCell(style: .subtitle, reuseIdentifier: "cell")
+    let collection: InternetArchive.ItemMetadata = collections[indexPath.row]
+    cell.textLabel?.text = collection.title?.value ?? collection.identifier
+    cell.detailTextLabel?.text = collection.identifier
+    return cell
+  }
+}

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -36,7 +36,7 @@ class InternetArchiveKitTests: XCTestCase {
       return nil
     }
 
-    func generateScrapeUrl(query: InternetArchiveURLStringProtocol, fields: [String], sortFields: [InternetArchiveURLQueryItemProtocol], cursor: String?, additionalQueryParams: [URLQueryItem]) -> URL? {
+    func generateScrapeUrl(query: InternetArchiveURLStringProtocol, fields: [String], sortFields: [InternetArchiveURLQueryItemProtocol], pagination: InternetArchive.ScrapePagination?, additionalQueryParams: [URLQueryItem]) -> URL? {
       return nil
     }
   }
@@ -413,7 +413,7 @@ class InternetArchiveKitTests: XCTestCase {
         archive.scrape(
           query: query,
           fields: ["identifier"],
-          cursor: cursor,
+          pagination: .cursor(cursor),
           completion: { (secondBatch: InternetArchive.ScrapeResponse?, error: Error?) in
             if let secondBatch = secondBatch {
               XCTAssertTrue(secondBatch.items.count > 0)
@@ -430,13 +430,33 @@ class InternetArchiveKitTests: XCTestCase {
     wait(for: [expectation], timeout: 30.0)
   }
 
+  // `.count(n)` returns exactly n items in a single bounded batch.
+  func testScrapeCount() {
+    let expectation = XCTestExpectation(description: "Test Scrape Count")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    InternetArchive().scrape(
+      query: query,
+      fields: ["identifier"],
+      pagination: .count(150),
+      completion: { (response: InternetArchive.ScrapeResponse?, error: Error?) in
+        if let response = response {
+          XCTAssertEqual(response.items.count, 150)
+        } else {
+          XCTFail("no response, error: \(error?.localizedDescription ?? "unknown")")
+        }
+        expectation.fulfill()
+    })
+
+    wait(for: [expectation], timeout: 20.0)
+  }
+
   func testScrapeAsyncThrows() async throws {
     let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
     let response: InternetArchive.ScrapeResponse = try await InternetArchive().scrape(
       query: query,
       fields: ["identifier"],
       sortFields: nil,
-      cursor: nil
+      pagination: nil
     )
     XCTAssertTrue(response.total > 7000)  // the etree archive has 9000+ collections so just sanity check
     XCTAssertTrue(response.items.count > 0)
@@ -448,7 +468,7 @@ class InternetArchiveKitTests: XCTestCase {
     do {
       // the type annotation selects the `async throws` overload over the `async -> Result` one
       let _: InternetArchive.ScrapeResponse = try await archive.scrape(
-        query: query, fields: nil, sortFields: nil, cursor: nil)
+        query: query, fields: nil, sortFields: nil, pagination: nil)
       XCTFail("expected an error")
     } catch {
       XCTAssertEqual(error as? InternetArchive.InternetArchiveError, .invalidUrl)

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -522,4 +522,31 @@ class InternetArchiveKitTests: XCTestCase {
     }
   }
 
+  // archive.org rejects a scrape sort where `identifier` is not the last key. The library catches
+  // it client-side and fails before sending the request.
+  func testScrapeRejectsMisplacedIdentifierSort() {
+    let expectation = XCTestExpectation(description: "Test Scrape Rejects Misplaced Identifier Sort")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let sortFields: [InternetArchive.SortField] = [
+      InternetArchive.SortField(field: "identifier", direction: .asc),
+      InternetArchive.SortField(field: "date", direction: .desc)
+    ]
+    InternetArchive().scrape(
+      query: query,
+      fields: ["identifier"],
+      sortFields: sortFields,
+      completion: { (response: InternetArchive.ScrapeResponse?, error: Error?) in
+        XCTAssertNil(response)
+        XCTAssertEqual(
+          error as? InternetArchive.InternetArchiveError,
+          .invalidSortFields(message: "'identifier' must be the last sort field"))
+        XCTAssertEqual(
+          (error as? InternetArchive.InternetArchiveError)?.errorDescription,
+          "Invalid sort fields: 'identifier' must be the last sort field")
+        expectation.fulfill()
+    })
+
+    wait(for: [expectation], timeout: 10)
+  }
+
 }

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -430,4 +430,29 @@ class InternetArchiveKitTests: XCTestCase {
     wait(for: [expectation], timeout: 30.0)
   }
 
+  func testScrapeAsyncThrows() async throws {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let response: InternetArchive.ScrapeResponse = try await InternetArchive().scrape(
+      query: query,
+      fields: ["identifier"],
+      sortFields: nil,
+      cursor: nil
+    )
+    XCTAssertTrue(response.total > 7000)  // the etree archive has 9000+ collections so just sanity check
+    XCTAssertTrue(response.items.count > 0)
+  }
+
+  func testScrapeAsyncThrowsInvalidUrl() async {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree"])
+    let archive = InternetArchive(urlGenerator: BadUrlGenerator(), urlSession: URLSession.mock)
+    do {
+      // the type annotation selects the `async throws` overload over the `async -> Result` one
+      let _: InternetArchive.ScrapeResponse = try await archive.scrape(
+        query: query, fields: nil, sortFields: nil, cursor: nil)
+      XCTFail("expected an error")
+    } catch {
+      XCTAssertEqual(error as? InternetArchive.InternetArchiveError, .invalidUrl)
+    }
+  }
+
 }

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -475,4 +475,51 @@ class InternetArchiveKitTests: XCTestCase {
     }
   }
 
+  // `scrapeTotal` returns just the match count (the Scrape API's `total_only`), fetching no items.
+  func testScrapeTotal() {
+    let expectation = XCTestExpectation(description: "Test Scrape Total")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    InternetArchive().scrapeTotal(
+      query: query,
+      completion: { (total: Int?, error: Error?) in
+        if let total = total {
+          XCTAssertTrue(total > 7000)  // the etree archive has 9000+ collections so just sanity check
+        } else {
+          XCTFail("no total, error: \(error?.localizedDescription ?? "unknown")")
+        }
+        expectation.fulfill()
+    })
+
+    wait(for: [expectation], timeout: 20.0)
+  }
+
+  func testBadScrapeTotalUrl() {
+    let expectation = XCTestExpectation(description: "Test Bad Scrape Total URL")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree"])
+    let archive = InternetArchive(urlGenerator: BadUrlGenerator(), urlSession: URLSession.mock)
+    archive.scrapeTotal(query: query) { (_: Int?, error: Error?) in
+      XCTAssertEqual(error as! InternetArchive.InternetArchiveError, InternetArchive.InternetArchiveError.invalidUrl)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testScrapeTotalAsyncThrows() async throws {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let total: Int = try await InternetArchive().scrapeTotal(query: query)
+    XCTAssertTrue(total > 7000)  // the etree archive has 9000+ collections so just sanity check
+  }
+
+  func testScrapeTotalAsyncThrowsInvalidUrl() async {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree"])
+    let archive = InternetArchive(urlGenerator: BadUrlGenerator(), urlSession: URLSession.mock)
+    do {
+      // the type annotation selects the `async throws` overload over the `async -> Result` one
+      let _: Int = try await archive.scrapeTotal(query: query)
+      XCTFail("expected an error")
+    } catch {
+      XCTAssertEqual(error as? InternetArchive.InternetArchiveError, .invalidUrl)
+    }
+  }
+
 }

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -35,6 +35,10 @@ class InternetArchiveKitTests: XCTestCase {
     func generateSearchUrl(query: InternetArchiveURLStringProtocol, page: Int, rows: Int, fields: [String], sortFields: [InternetArchiveURLQueryItemProtocol], additionalQueryParams: [URLQueryItem]) -> URL? {
       return nil
     }
+
+    func generateScrapeUrl(query: InternetArchiveURLStringProtocol, fields: [String], sortFields: [InternetArchiveURLQueryItemProtocol], cursor: String?, additionalQueryParams: [URLQueryItem]) -> URL? {
+      return nil
+    }
   }
 
   func testBadSearchUrl() {
@@ -44,6 +48,19 @@ class InternetArchiveKitTests: XCTestCase {
     let mockSession = URLSession.mock
     let archive = InternetArchive(urlGenerator: urlGenerator, urlSession: mockSession)
     archive.search(query: query, page: 0, rows: 10) { (_: InternetArchive.SearchResponse?, error: Error?) in
+      XCTAssertEqual(error as! InternetArchive.InternetArchiveError, InternetArchive.InternetArchiveError.invalidUrl)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testBadScrapeUrl() {
+    let expectation = XCTestExpectation(description: "Test Bad Scrape URL")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let urlGenerator = BadUrlGenerator()
+    let mockSession = URLSession.mock
+    let archive = InternetArchive(urlGenerator: urlGenerator, urlSession: mockSession)
+    archive.scrape(query: query) { (_: InternetArchive.ScrapeResponse?, error: Error?) in
       XCTAssertEqual(error as! InternetArchive.InternetArchiveError, InternetArchive.InternetArchiveError.invalidUrl)
       expectation.fulfill()
     }
@@ -346,6 +363,71 @@ class InternetArchiveKitTests: XCTestCase {
 
     wait(for: [expectation], timeout: 20.0)
 
+  }
+
+  func testScrape() {
+    let expectation = XCTestExpectation(description: "Test Scrape")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    InternetArchive().scrape(
+      query: query,
+      fields: ["identifier", "title"],
+      completion: { (response: InternetArchive.ScrapeResponse?, error: Error?) in
+        if let error: Error = error {
+          XCTFail("error, \(error.localizedDescription)")
+          expectation.fulfill()
+          return
+        }
+
+        if let response = response {
+          XCTAssertTrue(response.total > 7000)  // the etree archive has 9000+ collections so just sanity check
+          XCTAssertTrue(response.items.count > 100)  // archive.org returns a large server-sized batch
+          XCTAssertEqual(response.count, response.items.count)  // `count` reports this batch's size
+          XCTAssertNotNil(response.items.first?.title)
+          XCTAssertNotNil(response.cursor)  // more results remain, so a cursor is returned
+        } else {
+          XCTFail("no response")
+        }
+        expectation.fulfill()
+    })
+
+    wait(for: [expectation], timeout: 20.0)
+  }
+
+  // The Scrape API scrolls forward with a cursor: pass the cursor from the first batch into a second
+  // request and the results should continue where the first left off, with no overlap.
+  func testScrapeCursor() {
+    let expectation = XCTestExpectation(description: "Test Scrape Cursor")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let archive = InternetArchive()
+
+    archive.scrape(
+      query: query,
+      fields: ["identifier"],
+      completion: { (firstBatch: InternetArchive.ScrapeResponse?, error: Error?) in
+        guard let firstBatch = firstBatch, let cursor = firstBatch.cursor else {
+          XCTFail("no first batch or cursor")
+          expectation.fulfill()
+          return
+        }
+
+        archive.scrape(
+          query: query,
+          fields: ["identifier"],
+          cursor: cursor,
+          completion: { (secondBatch: InternetArchive.ScrapeResponse?, error: Error?) in
+            if let secondBatch = secondBatch {
+              XCTAssertTrue(secondBatch.items.count > 0)
+              let firstIds: Set<String> = Set(firstBatch.items.map { $0.identifier })
+              let secondIds: Set<String> = Set(secondBatch.items.map { $0.identifier })
+              XCTAssertTrue(firstIds.isDisjoint(with: secondIds))  // the cursor advanced past the first batch
+            } else {
+              XCTFail("no second batch")
+            }
+            expectation.fulfill()
+        })
+    })
+
+    wait(for: [expectation], timeout: 30.0)
   }
 
 }

--- a/InternetArchiveKitTests/ScrapeResponseTests.swift
+++ b/InternetArchiveKitTests/ScrapeResponseTests.swift
@@ -1,0 +1,29 @@
+//
+//  ScrapeResponseTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 6/23/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+@testable import InternetArchiveKit
+
+class ScrapeResponseTests: XCTestCase {
+  func testInit() {
+    let item = InternetArchive.ItemMetadata(identifier: "foo")
+    let response = InternetArchive.ScrapeResponse(
+      items: [item], count: 1, total: 10, cursor: "next", previous: "prev")
+    XCTAssertEqual(response.items.first?.identifier, "foo")
+    XCTAssertEqual(response.count, 1)
+    XCTAssertEqual(response.total, 10)
+    XCTAssertEqual(response.cursor, "next")
+    XCTAssertEqual(response.previous, "prev")
+  }
+
+  func testInitDefaultsCursorAndPreviousToNil() {
+    let response = InternetArchive.ScrapeResponse(items: [], count: 0, total: 0)
+    XCTAssertNil(response.cursor)
+    XCTAssertNil(response.previous)
+  }
+}

--- a/InternetArchiveKitTests/URLGeneratorTests.swift
+++ b/InternetArchiveKitTests/URLGeneratorTests.swift
@@ -44,7 +44,7 @@ class APIControllerTests: XCTestCase {
       let url: URL = urlGenerator.generateScrapeUrl(query: query,
                                                     fields: ["identifier", "title"],
                                                     sortFields: [sortField],
-                                                    cursor: "abc123",
+                                                    pagination: .cursor("abc123"),
                                                     additionalQueryParams: []),
       let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
         XCTFail("Error generating scrape URL")
@@ -61,6 +61,26 @@ class APIControllerTests: XCTestCase {
     XCTAssertEqual(items["fields"], "identifier,title")  // comma-delimited, not repeated fl[]
     XCTAssertEqual(items["sorts"], "date desc")  // comma-delimited, not repeated sort[]
     XCTAssertEqual(items["cursor"], "abc123")
+    XCTAssertNil(items["count"])  // `.cursor` and `.count` are mutually exclusive
+  }
+
+  func testGenerateScrapeUrlWithCount() {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar"])
+    guard
+      let url: URL = urlGenerator.generateScrapeUrl(query: query,
+                                                    fields: [],
+                                                    sortFields: [],
+                                                    pagination: .count(500),
+                                                    additionalQueryParams: []),
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        XCTFail("Error generating scrape URL")
+        return
+    }
+
+    let items: [String: String] = (components.queryItems ?? []).reduce(into: [:]) { $0[$1.name] = $1.value }
+    XCTAssertEqual(items["count"], "500")
+    XCTAssertNil(items["cursor"])  // `.count` and `.cursor` are mutually exclusive
   }
 
   func testGenerateScrapeUrlOmitsEmptyParams() {
@@ -70,7 +90,7 @@ class APIControllerTests: XCTestCase {
       let url: URL = urlGenerator.generateScrapeUrl(query: query,
                                                     fields: [],
                                                     sortFields: [],
-                                                    cursor: nil,
+                                                    pagination: nil,
                                                     additionalQueryParams: []),
       let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
         XCTFail("Error generating scrape URL")
@@ -82,6 +102,7 @@ class APIControllerTests: XCTestCase {
     XCTAssertFalse(names.contains("fields"))
     XCTAssertFalse(names.contains("sorts"))
     XCTAssertFalse(names.contains("cursor"))
+    XCTAssertFalse(names.contains("count"))
   }
 
   func testGenerateDownloadUrl() {

--- a/InternetArchiveKitTests/URLGeneratorTests.swift
+++ b/InternetArchiveKitTests/URLGeneratorTests.swift
@@ -36,6 +36,54 @@ class APIControllerTests: XCTestCase {
     }
   }
 
+  func testGenerateScrapeUrl() {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar"])
+    let sortField: InternetArchive.SortField = InternetArchive.SortField(field: "date", direction: .desc)
+    guard
+      let url: URL = urlGenerator.generateScrapeUrl(query: query,
+                                                    fields: ["identifier", "title"],
+                                                    sortFields: [sortField],
+                                                    cursor: "abc123",
+                                                    additionalQueryParams: []),
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        XCTFail("Error generating scrape URL")
+        return
+    }
+
+    XCTAssertEqual(components.scheme, "gopher")
+    XCTAssertEqual(components.host, "foohost.org")
+    XCTAssertEqual(components.path, "/services/search/v1/scrape")
+
+    // parse the query items back so the assertions don't depend on percent-encoding
+    let items: [String: String] = (components.queryItems ?? []).reduce(into: [:]) { $0[$1.name] = $1.value }
+    XCTAssertEqual(items["q"], "(foo:(bar))")
+    XCTAssertEqual(items["fields"], "identifier,title")  // comma-delimited, not repeated fl[]
+    XCTAssertEqual(items["sorts"], "date desc")  // comma-delimited, not repeated sort[]
+    XCTAssertEqual(items["cursor"], "abc123")
+  }
+
+  func testGenerateScrapeUrlOmitsEmptyParams() {
+    let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["foo": "bar"])
+    guard
+      let url: URL = urlGenerator.generateScrapeUrl(query: query,
+                                                    fields: [],
+                                                    sortFields: [],
+                                                    cursor: nil,
+                                                    additionalQueryParams: []),
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        XCTFail("Error generating scrape URL")
+        return
+    }
+
+    let names: Set<String> = Set((components.queryItems ?? []).map { $0.name })
+    XCTAssertTrue(names.contains("q"))
+    XCTAssertFalse(names.contains("fields"))
+    XCTAssertFalse(names.contains("sorts"))
+    XCTAssertFalse(names.contains("cursor"))
+  }
+
   func testGenerateDownloadUrl() {
     let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
     if let url: URL = urlGenerator.generateDownloadUrl(itemIdentifier: "foo", fileName: "bar") {

--- a/InternetArchiveKitTests/URLGeneratorTests.swift
+++ b/InternetArchiveKitTests/URLGeneratorTests.swift
@@ -105,6 +105,23 @@ class APIControllerTests: XCTestCase {
     XCTAssertFalse(names.contains("count"))
   }
 
+  func testScrapeSortMisplacesIdentifier() {
+    let id = InternetArchive.SortField(field: "identifier", direction: .asc)
+    let date = InternetArchive.SortField(field: "date", direction: .desc)
+    let downloads = InternetArchive.SortField(field: "downloads", direction: .desc)
+
+    // valid: identifier absent, alone, or last
+    XCTAssertFalse(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([]))
+    XCTAssertFalse(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([date]))
+    XCTAssertFalse(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([id]))
+    XCTAssertFalse(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([date, id]))
+    XCTAssertFalse(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([downloads, id]))
+
+    // invalid: identifier present but not last
+    XCTAssertTrue(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([id, date]))
+    XCTAssertTrue(InternetArchive.URLGenerator.scrapeSortMisplacesIdentifier([id, downloads, date]))
+  }
+
   func testGenerateDownloadUrl() {
     let urlGenerator = InternetArchive.URLGenerator(host: "foohost.org", scheme: "gopher")
     if let url: URL = urlGenerator.generateDownloadUrl(itemIdentifier: "foo", fileName: "bar") {

--- a/README.md
+++ b/README.md
@@ -44,9 +44,28 @@ case .failure(let error):
 
 For more advanced usage, see the test suite and the included sample app.
 
-## Scraping large result sets
+## `search()` vs `scrape()`
 
-`search()` is great for paged, sorted, interactive queries, but archive.org caps it at the 10,000th result. To walk an entire result set (a whole collection, every recording for an artist), use `scrape()`. It pages forward with a cursor instead of page numbers, so it can read past that ceiling. Start with `cursor: nil`, then pass each response's `cursor` back in until it comes back `nil`:
+Both run the same Lucene-style query against the same index, but they're built for different jobs.
+
+- **`search()`** (advancedsearch.php) is for **interactive, paged queries**: show page 3, sort by relevance, get a result count. Use it behind a search box or a paginated list.
+- **`scrape()`** (the Scrape API) is for **reading an entire result set**: every recording in a collection, every show for an artist. It's the only way to get more than 10,000 results.
+
+| | `search()` | `scrape()` |
+| --- | --- | --- |
+| Pagination | random access (`page` / `rows`) | forward-only `cursor` |
+| Results reachable | first 10,000 | the whole set |
+| Batch size | you choose (`rows`) | fixed server-side (~5,000) |
+| Total match count | `response.numFound` | `total` |
+| Results live in | `response.docs` | `items` |
+| Sorting | any | any, but a custom sort caps out at 10,000 results |
+| Relevance ranking and facets | yes | no |
+
+Rule of thumb: if you're showing results to a person a page at a time, reach for `search()`. If you're pulling a whole collection down to process or cache, reach for `scrape()`.
+
+### Scraping
+
+`scrape()` pages forward with a cursor. Start with `cursor: nil`, then pass each response's `cursor` back in until it comes back `nil`:
 
 ```swift
 let query = InternetArchive.Query(
@@ -70,7 +89,11 @@ repeat {
 } while cursor != nil
 ```
 
-archive.org fixes the batch size server-side (~5,000 items per request). If you pass `sortFields`, custom-sorted scraping is still capped at 10,000 results, and `identifier`, if you sort on it, must be the last sort field.
+A few nuances:
+
+- **There's no page-size parameter, on purpose.** archive.org ignores the cursor if you also send a `count`, silently re-serving the first batch every time. So `scrape()` pages by cursor alone at the server's default batch size (~5,000 items). This is what archive.org's own `internetarchive` Python client does.
+- **A custom sort caps scraping at 10,000 results.** Leave `sortFields` empty to scroll the full set (it walks in `identifier` order). If you do sort and include `identifier`, it has to be the last sort field.
+- **No relevance ranking or faceting.** The Scrape API doesn't offer either; if you need them, use `search()`.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Both run the same Lucene-style query against the same index, but they're built f
 | --- | --- | --- |
 | Pagination | random access (`page` / `rows`) | forward-only `cursor` |
 | Results reachable | first 10,000 | the whole set |
-| Batch size | you choose (`rows`) | fixed server-side (~5,000) |
+| Batch size | you choose (`rows`) | `.count` for one batch, else ~5,000 |
 | Total match count | `response.numFound` | `total` |
 | Results live in | `response.docs` | `items` |
 | Sorting | any | any, but a custom sort caps out at 10,000 results |
@@ -65,33 +65,34 @@ Rule of thumb: if you're showing results to a person a page at a time, reach for
 
 ### Scraping
 
-`scrape()` pages forward with a cursor. Start with `cursor: nil`, then pass each response's `cursor` back in until it comes back `nil`:
+`scrape()` pages forward with a cursor. Start with `pagination: nil`, then pass each response's `cursor` back as `.cursor(...)` until it comes back `nil`:
 
 ```swift
 let query = InternetArchive.Query(
   clauses: ["collection": "etree", "mediatype": "collection"])
 let archive = InternetArchive()
 
-var cursor: String? = nil
+var pagination: InternetArchive.ScrapePagination? = nil
 var identifiers: [String] = []
 
 repeat {
   let result = await archive.scrape(
-    query: query, fields: ["identifier"], sortFields: nil, cursor: cursor)
+    query: query, fields: ["identifier"], sortFields: nil, pagination: pagination)
   switch result {
   case .success(let response):
     identifiers += response.items.map { $0.identifier }
-    cursor = response.cursor  // nil on the last batch
+    pagination = response.cursor.map { .cursor($0) }  // nil on the last batch ends the loop
   case .failure(let error):
     // debugPrint(error)
-    cursor = nil
+    pagination = nil
   }
-} while cursor != nil
+} while pagination != nil
 ```
 
 A few nuances:
 
-- **There's no page-size parameter, on purpose.** archive.org ignores the cursor if you also send a `count`, silently re-serving the first batch every time. So `scrape()` pages by cursor alone at the server's default batch size (~5,000 items). This is what archive.org's own `internetarchive` Python client does.
+- **Pagination is a single value, by design.** `pagination` is either `.cursor(...)` to resume or `.count(n)` to size a batch, never both: archive.org ignores the cursor if you also send a `count`, so the type makes that broken combination unrepresentable. Pass `nil` for the first batch at the server's default size (~5,000 items).
+- **`.count` is for a bounded pull.** Use `.count(n)` (100–10,000) to grab up to 10,000 matches in one request, or a smaller first page before scrolling. It sizes only the batch it rides on; once you continue with `.cursor`, batches revert to the server default (~5,000). To page through everything, leave `pagination` `nil` and scroll by cursor (what archive.org's own `internetarchive` Python client does).
 - **A custom sort caps scraping at 10,000 results.** Leave `sortFields` empty to scroll the full set (it walks in `identifier` order). If you do sort and include `identifier`, it has to be the last sort field.
 - **No relevance ranking or faceting.** The Scrape API doesn't offer either; if you need them, use `search()`.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ A few nuances:
 - **A custom sort caps scraping at 10,000 results.** Leave `sortFields` empty to scroll the full set (it walks in `identifier` order). If you do sort and include `identifier`, it has to be the last sort field.
 - **No relevance ranking or faceting.** The Scrape API doesn't offer either; if you need them, use `search()`.
 
+Need only the count? `scrapeTotal(query:)` returns the match total without fetching any items:
+
+```swift
+let result = await archive.scrapeTotal(query: query)
+// result == .success(9250)
+```
+
 ## Limitations
 
 Currently, InternetArchiveKit is read-only and does not have support for all of Internet Archive's data. Pull requests are welcome!

--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ case .failure(let error):
 
 For more advanced usage, see the test suite and the included sample app.
 
+## Scraping large result sets
+
+`search()` is great for paged, sorted, interactive queries, but archive.org caps it at the 10,000th result. To walk an entire result set (a whole collection, every recording for an artist), use `scrape()`. It pages forward with a cursor instead of page numbers, so it can read past that ceiling. Start with `cursor: nil`, then pass each response's `cursor` back in until it comes back `nil`:
+
+```swift
+let query = InternetArchive.Query(
+  clauses: ["collection": "etree", "mediatype": "collection"])
+let archive = InternetArchive()
+
+var cursor: String? = nil
+var identifiers: [String] = []
+
+repeat {
+  let result = await archive.scrape(
+    query: query, fields: ["identifier"], sortFields: nil, cursor: cursor)
+  switch result {
+  case .success(let response):
+    identifiers += response.items.map { $0.identifier }
+    cursor = response.cursor  // nil on the last batch
+  case .failure(let error):
+    // debugPrint(error)
+    cursor = nil
+  }
+} while cursor != nil
+```
+
+archive.org fixes the batch size server-side (~5,000 items per request). If you pass `sortFields`, custom-sorted scraping is still capped at 10,000 results, and `identifier`, if you sort on it, must be the last sort field.
+
 ## Limitations
 
 Currently, InternetArchiveKit is read-only and does not have support for all of Internet Archive's data. Pull requests are welcome!

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A few nuances:
 
 - **Pagination is a single value, by design.** `pagination` is either `.cursor(...)` to resume or `.count(n)` to size a batch, never both: archive.org ignores the cursor if you also send a `count`, so the type makes that broken combination unrepresentable. Pass `nil` for the first batch at the server's default size (~5,000 items).
 - **`.count` is for a bounded pull.** Use `.count(n)` (100–10,000) to grab up to 10,000 matches in one request, or a smaller first page before scrolling. It sizes only the batch it rides on; once you continue with `.cursor`, batches revert to the server default (~5,000). To page through everything, leave `pagination` `nil` and scroll by cursor (what archive.org's own `internetarchive` Python client does).
-- **A custom sort caps scraping at 10,000 results.** Leave `sortFields` empty to scroll the full set (it walks in `identifier` order). If you do sort and include `identifier`, it has to be the last sort field.
+- **A custom sort caps scraping at 10,000 results.** Leave `sortFields` empty to scroll the full set (it walks in `identifier` order). If you do sort and include `identifier`, it has to be the last sort field; otherwise `scrape()` fails fast with `InternetArchiveError.invalidSortFields` before sending the request.
 - **No relevance ranking or faceting.** The Scrape API doesn't offer either; if you need them, use `search()`.
 
 Need only the count? `scrapeTotal(query:)` returns the match total without fetching any items:


### PR DESCRIPTION
Closes #33. `search()` (advancedsearch.php) can't page past the 10,000th result, so there's no way to enumerate a whole large collection. archive.org's Scrape API (`/services/search/v1/scrape`) scrolls an entire result set forward with a cursor. This adds `scrape()` alongside `search()` — they're complementary, not a swap. search() keeps random-access paging, sorting, and relevance for interactive queries; scrape() handles full-set enumeration.

## Changes

- **`scrape(query:fields:sortFields:cursor:)`** on `InternetArchive` — async `Result`, async `throws`, and completion-handler variants, mirroring `search()`. Reuses the existing generic `makeRequest`/`decodeResponse`, so the HTTP-200 `{"error": …}` envelope still surfaces as `InternetArchiveError.apiError`.
- **`ScrapeResponse`** — decodes the scrape envelope `{items, count, cursor, total, previous}`. `items` is the same `ItemMetadata` that `search()` returns in `docs`, so models are reused as-is.
- **`URLGenerator.generateScrapeUrl(...)`** — builds `/services/search/v1/scrape` with comma-delimited `fields`/`sorts` (not the repeated `fl[]`/`sort[]`). Reuses the oversized-`q` warning.
- **No `count` parameter, on purpose.** archive.org silently ignores `cursor` when `count` is also sent — it re-returns the first batch with no error. Paginating by cursor alone at the server default (~5,000 items/batch) is the only reliable path, and it's what the official `internetarchive` Python client does. Page forward until `cursor` comes back `nil`.

## Tests

- `testGenerateScrapeUrl` / `…OmitsEmptyParams` — URL shape, comma-delimited params, nil-param omission.
- `testScrape` — live call returns a batch + `total` + `cursor`.
- `testScrapeCursor` — live call passes the first cursor into a second request and asserts the batches are disjoint, i.e. the cursor actually advances. This is what caught the count/cursor gotcha above (a URL-shape unit test alone passed while the second page silently repeated the first).
- `testBadScrapeUrl` — invalid-URL path → `.invalidUrl`.
- Full suite green via `swift test` (96 tests, includes the live-network tests). No new SwiftLint warnings.

README has a short "Scraping large result sets" section with the cursor loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)