### PR TITLE
Adopt Swift 6 in the example app; make the query API Sendable

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -36,7 +36,10 @@ let logSubsystemId: String = "engineering.astral.internetarchivekit"
 ///    // debugPrint(error)
 /// }
 /// ```
-public class InternetArchive: InternetArchiveProtocol {
+public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable {
+  // Safe to share across concurrency domains: every stored property is a `let`
+  // and requests run through the thread-safe `URLSession`. `@unchecked` is only
+  // needed because the injected URL generator and JSON decoder aren't `Sendable`.
   public convenience init() {
     let urlGenerator = URLGenerator()
     self.init(urlGenerator: urlGenerator, urlSession: URLSession.shared)

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -238,12 +238,12 @@ public protocol InternetArchiveURLGeneratorProtocol {
 /// A protocol for abstracting URL search query strings
 ///
 /// All of the search queries components like Query and DateQuery conform to this
-public protocol InternetArchiveURLStringProtocol {
+public protocol InternetArchiveURLStringProtocol: Sendable {
   var asURLString: String? { get }
 }
 
 /// A protocol for abstracting URL query items for a search
-public protocol InternetArchiveURLQueryItemProtocol {
+public protocol InternetArchiveURLQueryItemProtocol: Sendable {
   var asQueryItem: URLQueryItem { get }
 }
 

--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -83,7 +83,7 @@ extension InternetArchive {
     }
   }
 
-  public enum QueryBooleanOperator: String {
+  public enum QueryBooleanOperator: String, Sendable {
     case and = "AND"
     case or = "OR"
   }
@@ -272,7 +272,7 @@ extension InternetArchive {
     }
   }
 
-  public enum QueryClauseBooleanOperator: String {
+  public enum QueryClauseBooleanOperator: String, Sendable {
     case and = ""
     case not = "-"  // if we want negate this query clause, put a minus before it, ie: `-collection:(foo)`
   }
@@ -306,7 +306,7 @@ extension InternetArchive {
     }
   }
 
-  public enum SortDirection: String {
+  public enum SortDirection: String, Sendable {
     case asc
     case desc
   }
@@ -332,7 +332,7 @@ extension InternetArchive {
    await archive.scrape(query: query, pagination: .cursor(previous.cursor!))
    ```
    */
-  public enum ScrapePagination {
+  public enum ScrapePagination: Sendable {
     /// Return this many items (archive.org allows 100–10,000) in a single
     /// batch. Use for a bounded one-shot pull, or as a smaller first page
     /// before scrolling. `count` sizes only the batch it is on; continuing

--- a/InternetArchiveKitExample.xcodeproj/project.pbxproj
+++ b/InternetArchiveKitExample.xcodeproj/project.pbxproj
@@ -167,7 +167,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jasonbuckner.InternetArchiveKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -186,7 +186,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.jasonbuckner.InternetArchiveKitExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
Closes #39.

Flips the example target to Swift 6 language mode (`SWIFT_VERSION = 6.0`). The only friction strict concurrency surfaced was the library's value-type API not being `Sendable`: a `@MainActor` view model calling the nonisolated async `search`/`itemDetail`/`scrape` hands `InternetArchive` and the query types across an isolation boundary.

So the fix lives in the library, and it's the right one (these are immutable value types that should be `Sendable`):
- `InternetArchive`: `final` + `@unchecked Sendable` (immutable, wraps the thread-safe `URLSession`).
- `InternetArchiveURLStringProtocol` / `InternetArchiveURLQueryItemProtocol` are now `Sendable`, so `Query`, `QueryClause`, the range clauses, and `SortField` pick it up.
- Query enums marked `Sendable` (`QueryBooleanOperator`, `QueryClauseBooleanOperator`, `SortDirection`, `ScrapePagination`).

The example's SwiftUI view models and the `@MainActor @Observable` `AudioPlayer` needed **zero** source changes. A `@MainActor` class is implicitly `Sendable` and its closures inherit that isolation, so the Combine / `MPRemoteCommandCenter` callbacks were already correct.

Helps any Swift 6 consumer of the library, not just the example. Builds clean (0 app warnings); `Sendable` is compile-time only, so runtime behavior is unchanged.
