### PR TITLE
Bump declared platforms to iOS 15 and macOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
   name: "InternetArchiveKit",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15)
+    .iOS(.v15),
+    .macOS(.v12)
   ],
   products: [
     .library(name: "InternetArchiveKit", targets: ["InternetArchiveKit"])


### PR DESCRIPTION
Closes #41. Note: current Xcode back-deploys the async URLSession wrappers, so the hard driver here is the Logger migration (#23) and floor honesty, see the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf