### PR TITLE
Add default arguments to the async search() and scrape()

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -66,8 +66,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     query: InternetArchiveURLStringProtocol,
     page: Int,
     rows: Int,
-    fields: [String]?,
-    sortFields: [InternetArchiveURLQueryItemProtocol]?
+    fields: [String]? = nil,
+    sortFields: [InternetArchiveURLQueryItemProtocol]? = nil
   ) async -> Result<SearchResponse, Error> {
     guard
       let searchUrl: URL = urlGenerator.generateSearchUrl(
@@ -120,9 +120,9 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   /** @inheritdoc */
   public func scrape(
     query: InternetArchiveURLStringProtocol,
-    fields: [String]?,
-    sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    pagination: ScrapePagination?
+    fields: [String]? = nil,
+    sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
+    pagination: ScrapePagination? = nil
   ) async -> Result<ScrapeResponse, Error> {
     if URLGenerator.scrapeSortMisplacesIdentifier(sortFields ?? []) {
       return .failure(

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -253,8 +253,8 @@ extension InternetArchiveProtocol {
     query: InternetArchiveURLStringProtocol,
     page: Int,
     rows: Int,
-    fields: [String]?,
-    sortFields: [InternetArchiveURLQueryItemProtocol]?
+    fields: [String]? = nil,
+    sortFields: [InternetArchiveURLQueryItemProtocol]? = nil
   ) async throws -> InternetArchive.SearchResponse {
     let result: Result<InternetArchive.SearchResponse, Error> = await search(
       query: query,
@@ -275,9 +275,9 @@ extension InternetArchiveProtocol {
   /** @inheritdoc */
   public func scrape(
     query: InternetArchiveURLStringProtocol,
-    fields: [String]?,
-    sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    pagination: InternetArchive.ScrapePagination?
+    fields: [String]? = nil,
+    sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
+    pagination: InternetArchive.ScrapePagination? = nil
   ) async throws -> InternetArchive.ScrapeResponse {
     let result: Result<InternetArchive.ScrapeResponse, Error> = await scrape(
       query: query,

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -475,6 +475,26 @@ class InternetArchiveKitTests: XCTestCase {
     }
   }
 
+  // The README's minimal call forms: `fields`, `sortFields`, and `pagination` all default to nil,
+  // so these also pin the defaults at compile time.
+  func testSearchMinimalArguments() async {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    let result = await InternetArchive().search(query: query, page: 1, rows: 10)
+    switch result {
+    case .success(let response):
+      XCTAssertTrue(response.response.docs.count > 0)
+    case .failure(let error):
+      XCTFail("error, \(error.localizedDescription)")
+    }
+  }
+
+  func testScrapeMinimalArguments() async throws {
+    let query: InternetArchive.Query = InternetArchive.Query(clauses: ["collection" : "etree", "mediatype": "collection"])
+    // the type annotation selects the `async throws` overload over the `async -> Result` one
+    let response: InternetArchive.ScrapeResponse = try await InternetArchive().scrape(query: query)
+    XCTAssertTrue(response.items.count > 0)
+  }
+
   // `scrapeTotal` returns just the match count (the Scrape API's `total_only`), fetching no items.
   func testScrapeTotal() {
     let expectation = XCTestExpectation(description: "Test Scrape Total")


### PR DESCRIPTION
Closes #42. The README example now compiles as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf