### PR TITLE
Surface non-2xx responses as httpError instead of decode errors

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -270,7 +270,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     let startTime: CFTimeInterval = CFAbsoluteTimeGetCurrent()
 
     do {
-      let (data, _) = try await urlSession.data(from: url)
+      let (data, response) = try await urlSession.data(from: url)
       let timeElapsed: CFTimeInterval = CFAbsoluteTimeGetCurrent() - startTime
       os_log(
         .info,
@@ -279,6 +279,20 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
         timeElapsed,
         url.absoluteString
       )
+
+      if let httpResponse = response as? HTTPURLResponse,
+        !(200..<300).contains(httpResponse.statusCode) {
+        // a rejected request can still carry the API's `{"error": …}`
+        // envelope, so prefer its message over a bare status code
+        if let envelope = try? jsonDecoder.decode(
+          APIErrorEnvelope.self, from: data
+        ) {
+          throw InternetArchiveError.apiError(message: envelope.error)
+        }
+        throw InternetArchiveError.httpError(
+          statusCode: httpResponse.statusCode)
+      }
+
       let results: T = try decodeResponse(data)
       return .success(results)
     } catch {

--- a/InternetArchiveKit/InternetArchiveErrors.swift
+++ b/InternetArchiveKit/InternetArchiveErrors.swift
@@ -28,6 +28,10 @@ extension InternetArchive {
     /// `identifier`, if it appears in a scrape sort, to be the last sort field.
     /// `message` explains what to fix.
     case invalidSortFields(message: String)
+
+    /// The server answered with a non-2xx HTTP status and the body carried
+    /// no `{"error": …}` envelope to explain it.
+    case httpError(statusCode: Int)
   }
 }
 
@@ -40,6 +44,8 @@ extension InternetArchive.InternetArchiveError: LocalizedError {
       return "Internet Archive API error: \(message)"
     case .invalidSortFields(let message):
       return "Invalid sort fields: \(message)"
+    case .httpError(let statusCode):
+      return "HTTP error \(statusCode)"
     }
   }
 }

--- a/InternetArchiveKitTests/HTTPStatusTests.swift
+++ b/InternetArchiveKitTests/HTTPStatusTests.swift
@@ -1,0 +1,98 @@
+//
+//  HTTPStatusTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 7/17/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+import URLSessionMock
+@testable import InternetArchiveKit
+
+/// Non-2xx responses surface as `InternetArchiveError.httpError` carrying the
+/// status code, unless the body carries the API's `{"error": …}` envelope,
+/// which is surfaced as `apiError` for its more useful message.
+class HTTPStatusTests: XCTestCase {
+
+  func test404SurfacesHttpError() {
+    let expectation = XCTestExpectation(description: "404 Response")
+    guard let data: Data = "<html>not found</html>".data(using: .utf8) else {
+      XCTFail("error encoding body to data")
+      return
+    }
+
+    let urlGenerator = InternetArchive.URLGenerator()
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["collection": "etree"])
+    guard
+      let url = urlGenerator.generateSearchUrl(
+        query: query, page: 1, rows: 10, fields: [], sortFields: [],
+        additionalQueryParams: [])
+    else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    let endpoint = BasicEndpointMock(
+      status: 404, url: url, body: data, headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    archive.search(query: query, page: 1, rows: 10) {
+      (response: InternetArchive.SearchResponse?, error: Error?) in
+      XCTAssertNil(response)
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.httpError(statusCode: 404)
+      )
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testNon2xxWithErrorEnvelopeStaysApiError() {
+    let expectation = XCTestExpectation(description: "400 With Envelope")
+    let errorMessage = "[BAD_REQUEST] The request could not be understood"
+    let json = "{\"error\": \"\(errorMessage)\"}"
+    guard let data: Data = json.data(using: .utf8) else {
+      XCTFail("error encoding json to data")
+      return
+    }
+
+    let urlGenerator = InternetArchive.URLGenerator()
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["collection": "etree"])
+    guard
+      let url = urlGenerator.generateSearchUrl(
+        query: query, page: 1, rows: 10, fields: [], sortFields: [],
+        additionalQueryParams: [])
+    else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    let endpoint = BasicEndpointMock(
+      status: 400, url: url, body: data, headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    archive.search(query: query, page: 1, rows: 10) {
+      (response: InternetArchive.SearchResponse?, error: Error?) in
+      XCTAssertNil(response)
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.apiError(message: errorMessage)
+      )
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+  }
+
+  func testHttpErrorLocalizedDescription() {
+    let error = InternetArchive.InternetArchiveError.httpError(statusCode: 503)
+    XCTAssertEqual(error.errorDescription, "HTTP error 503")
+  }
+}


### PR DESCRIPTION
Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf