### PR TITLE
Convert legacy os_log calls to the modern OSLog Logger API

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import ZippyJSON
-import os.log
+import OSLog
 
 let logSubsystemId: String = "engineering.astral.internetarchivekit"
 
@@ -79,11 +79,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
         additionalQueryParams: []
       )
     else {
-      os_log(
-        .error,
-        log: log,
-        "Error generating search url: %@",
-        query.asURLString ?? "Unknown query.asURLString"
+      logger.error(
+        "Error generating search url: \(query.asURLString ?? "Unknown query.asURLString")"
       )
       return .failure(InternetArchiveError.invalidUrl)
     }
@@ -141,11 +138,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
         additionalQueryParams: []
       )
     else {
-      os_log(
-        .error,
-        log: log,
-        "Error generating scrape url: %@",
-        query.asURLString ?? "Unknown query.asURLString"
+      logger.error(
+        "Error generating scrape url: \(query.asURLString ?? "Unknown query.asURLString")"
       )
       return .failure(InternetArchiveError.invalidUrl)
     }
@@ -193,11 +187,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
         ]
       )
     else {
-      os_log(
-        .error,
-        log: log,
-        "Error generating scrapeTotal url: %@",
-        query.asURLString ?? "Unknown query.asURLString"
+      logger.error(
+        "Error generating scrapeTotal url: \(query.asURLString ?? "Unknown query.asURLString")"
       )
       return .failure(InternetArchiveError.invalidUrl)
     }
@@ -229,11 +220,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
         identifier: identifier
       )
     else {
-      os_log(
-        .error,
-        log: log,
-        "itemDetail error generating metadata url, identifier: %{public}@",
-        identifier
+      logger.error(
+        "itemDetail error generating metadata url, identifier: \(identifier, privacy: .public)"
       )
       return .failure(InternetArchiveError.invalidUrl)
     }
@@ -261,32 +249,20 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
 
   private func makeRequest<T>(url: URL) async -> Result<T, Error>
   where T: Decodable {
-    os_log(
-      .info,
-      log: log,
-      "makeRequest start, url: %{public}@",
-      url.absoluteString
-    )
+    logger.info("makeRequest start, url: \(url.absoluteString, privacy: .public)")
     let startTime: CFTimeInterval = CFAbsoluteTimeGetCurrent()
 
     do {
       let (data, _) = try await urlSession.data(from: url)
       let timeElapsed: CFTimeInterval = CFAbsoluteTimeGetCurrent() - startTime
-      os_log(
-        .info,
-        log: log,
-        "makeRequest completed in %{public}f s, url: %{public}@",
-        timeElapsed,
-        url.absoluteString
+      logger.info(
+        "makeRequest completed in \(timeElapsed, privacy: .public) s, url: \(url.absoluteString, privacy: .public)"
       )
       let results: T = try decodeResponse(data)
       return .success(results)
     } catch {
-      os_log(
-        .error,
-        log: log,
-        "makeRequest, error: %{public}@",
-        error.localizedDescription
+      logger.error(
+        "makeRequest, error: \(error.localizedDescription, privacy: .public)"
       )
       return .failure(error)
     }
@@ -312,7 +288,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
 
   private let urlSession: URLSession
 
-  private let log: OSLog = OSLog(
+  private let logger: Logger = Logger(
     subsystem: logSubsystemId,
     category: "InternetArchive"
   )

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import os.log
+import OSLog
 
 extension InternetArchive {
   public class URLGenerator: InternetArchiveURLGeneratorProtocol {
@@ -208,15 +208,10 @@ extension InternetArchive {
     private func warnIfQueryExceedsRecommendedLength(_ queryString: String?) {
       guard Self.queryExceedsRecommendedLength(queryString),
             let queryString = queryString else { return }
-      os_log(
-        .error,
-        log: log,
-        // os_log formats are StaticStrings and can't be split across lines
+      logger.error(
+        // Logger messages are single string-interpolation literals and can't be split across lines
         // swiftlint:disable:next line_length
-        "search query is %{public}d chars; archive.org rejects q over ~2,000. Chunk against URLGenerator.recommendedMaxQueryLength (%{public}d). Query prefix: %{public}@",
-        queryString.count,
-        Self.recommendedMaxQueryLength,
-        String(queryString.prefix(120))
+        "search query is \(queryString.count, privacy: .public) chars; archive.org rejects q over ~2,000. Chunk against URLGenerator.recommendedMaxQueryLength (\(Self.recommendedMaxQueryLength, privacy: .public)). Query prefix: \(String(queryString.prefix(120)), privacy: .public)"
       )
       assertionFailure(
         "archive.org search query is \(queryString.count) chars — over the "
@@ -228,7 +223,7 @@ extension InternetArchive {
     private let host: String
     private let scheme: String
 
-    private let log: OSLog = OSLog(
+    private let logger: Logger = Logger(
       subsystem: logSubsystemId,
       category: "URLGenerator"
     )

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
   name: "InternetArchiveKit",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15)
+    .iOS(.v15),
+    .macOS(.v12)
   ],
   products: [
     .library(name: "InternetArchiveKit", targets: ["InternetArchiveKit"])


### PR DESCRIPTION
Closes #23. Carries the same Package.swift platform bump as #59 (Logger needs iOS 14/macOS 11); whichever merges second is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf