### PR TITLE
Deprecate the completion-handler API variants

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -92,6 +92,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   }
 
   /** @inheritdoc */
+  @available(*, deprecated, message: "Use the async version instead")
   public func search(
     query: InternetArchiveURLStringProtocol,
     page: Int,
@@ -154,6 +155,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   }
 
   /** @inheritdoc */
+  @available(*, deprecated, message: "Use the async version instead")
   public func scrape(
     query: InternetArchiveURLStringProtocol,
     fields: [String]? = nil,
@@ -207,6 +209,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   }
 
   /** @inheritdoc */
+  @available(*, deprecated, message: "Use the async version instead")
   public func scrapeTotal(
     query: InternetArchiveURLStringProtocol,
     completion: @escaping (Int?, Error?) -> Void
@@ -242,6 +245,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   }
 
   /** @inheritdoc */
+  @available(*, deprecated, message: "Use the async version instead")
   public func itemDetail(
     identifier: String,
     completion: @escaping (InternetArchive.Item?, Error?) -> Void

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -65,6 +65,7 @@ public protocol InternetArchiveProtocol {
    - sortFields: The fields by which you want to sort the results as an `InternetArchiveURLQueryItemProtocol` object
    - completion: Returns optional `InternetArchive.SearchResponse` and `Error` objects
    */
+  @available(*, deprecated, message: "Use the async version instead")
   func search(
     query: InternetArchiveURLStringProtocol,
     page: Int,
@@ -131,6 +132,7 @@ public protocol InternetArchiveProtocol {
    - pagination: `.cursor` to resume, `.count` to size a one-shot or first batch, or `nil` for the default first batch
    - completion: Returns optional `InternetArchive.ScrapeResponse` and `Error` objects
    */
+  @available(*, deprecated, message: "Use the async version instead")
   func scrape(
     query: InternetArchiveURLStringProtocol,
     fields: [String]?,
@@ -172,6 +174,7 @@ public protocol InternetArchiveProtocol {
    - query: The search query as an `InternetArchiveURLStringProtocol` object
    - completion: Returns an optional total count and `Error` object
    */
+  @available(*, deprecated, message: "Use the async version instead")
   func scrapeTotal(
     query: InternetArchiveURLStringProtocol,
     completion: @escaping (Int?, Error?) -> Void
@@ -207,6 +210,7 @@ public protocol InternetArchiveProtocol {
    - completion: Returns optional `InternetArchive.Item` and `Error` objects
    - returns: No value
    */
+  @available(*, deprecated, message: "Use the async version instead")
   func itemDetail(
     identifier: String,
     completion: @escaping (InternetArchive.Item?, Error?) -> Void


### PR DESCRIPTION
Closes #53. Annotations only; the completion tests stay while the API ships, so expect deprecation warnings in the test build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf