### PR TITLE
Add S3-key auth: injected credentials and a login helper

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -40,20 +40,27 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   // Safe to share across concurrency domains: every stored property is a `let`
   // and requests run through the thread-safe `URLSession`. `@unchecked` is only
   // needed because the injected URL generator and JSON decoder aren't `Sendable`.
-  public convenience init() {
+  public convenience init(credentials: Credentials? = nil) {
     let urlGenerator = URLGenerator()
-    self.init(urlGenerator: urlGenerator, urlSession: URLSession.shared)
+    self.init(
+      urlGenerator: urlGenerator,
+      urlSession: URLSession.shared,
+      credentials: credentials
+    )
   }
 
   public init(
     urlGenerator: InternetArchiveURLGeneratorProtocol,
-    urlSession: URLSession
+    urlSession: URLSession,
+    credentials: Credentials? = nil
   ) {
     self.urlGenerator = urlGenerator
     self.urlSession = urlSession
+    self.credentials = credentials
   }
 
   private let urlGenerator: InternetArchiveURLGeneratorProtocol
+  private let credentials: Credentials?
 
   private let jsonDecoder: ZippyJSONDecoder = {
     let decoder = ZippyJSONDecoder()
@@ -259,6 +266,78 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     }
   }
 
+  /** @inheritdoc */
+  public func login(
+    email: String,
+    password: String
+  ) async -> Result<Account, Error> {
+    guard let loginUrl: URL = urlGenerator.generateXauthnUrl(operation: "login")
+    else {
+      return .failure(InternetArchiveError.invalidUrl)
+    }
+
+    // nothing in this method is logged: it handles the account password
+    var request = URLRequest(url: loginUrl)
+    request.httpMethod = "POST"
+    request.setValue(
+      "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    request.httpBody = Self.formEncode([
+      ("email", email),
+      ("password", password),
+    ])
+
+    do {
+      let (data, _) = try await urlSession.data(for: request)
+      let envelope = try jsonDecoder.decode(XAuthnEnvelope.self, from: data)
+      guard
+        envelope.success,
+        let values = envelope.values,
+        let access = values.s3?.access,
+        let secret = values.s3?.secret
+      else {
+        let reason = envelope.values?.reason ?? "login failed"
+        return .failure(InternetArchiveError.apiError(message: reason))
+      }
+      let credentials = Credentials(
+        accessKey: access,
+        secretKey: secret,
+        cookies: values.cookies ?? [:]
+      )
+      return .success(
+        Account(credentials: credentials, screenname: values.screenname))
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  /// The request for `url` with the configured credentials attached, if any
+  private func authorizedRequest(url: URL) -> URLRequest {
+    var request = URLRequest(url: url)
+    if let credentials = credentials {
+      request.setValue(
+        credentials.authorizationHeaderValue, forHTTPHeaderField: "Authorization")
+      if let cookieHeader = credentials.cookieHeaderValue {
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+      }
+    }
+    return request
+  }
+
+  /// Percent-encode fields into an `application/x-www-form-urlencoded` body
+  static func formEncode(_ fields: [(String, String)]) -> Data? {
+    var allowed = CharacterSet.alphanumerics
+    allowed.insert(charactersIn: "-._~")
+    return fields.compactMap { (key: String, value: String) -> String? in
+      guard
+        let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed),
+        let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed)
+      else { return nil }
+      return "\(encodedKey)=\(encodedValue)"
+    }
+    .joined(separator: "&")
+    .data(using: .utf8)
+  }
+
   private func makeRequest<T>(url: URL) async -> Result<T, Error>
   where T: Decodable {
     os_log(
@@ -270,7 +349,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     let startTime: CFTimeInterval = CFAbsoluteTimeGetCurrent()
 
     do {
-      let (data, _) = try await urlSession.data(from: url)
+      let (data, _) = try await urlSession.data(for: authorizedRequest(url: url))
       let timeElapsed: CFTimeInterval = CFAbsoluteTimeGetCurrent() - startTime
       os_log(
         .info,

--- a/InternetArchiveKit/InternetArchiveAuth.swift
+++ b/InternetArchiveKit/InternetArchiveAuth.swift
@@ -1,0 +1,89 @@
+//
+//  InternetArchiveAuth.swift
+//  InternetArchiveKit
+//
+//  Created by Jason Buckner on 7/17/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import Foundation
+
+extension InternetArchive {
+  /**
+   archive.org credentials for authenticated requests.
+
+   The S3 key pair is attached to every request as
+   `Authorization: LOW access:secret`. Get keys from
+   [archive.org/account/s3.php](https://archive.org/account/s3.php), or
+   programmatically from `login(email:password:)`.
+
+   `cookies` are for website endpoints that want cookie auth rather than S3
+   keys; when present they're attached as a `Cookie` header.
+
+   InternetArchiveKit never stores credentials. Persisting them (for example
+   in the Keychain) is the app's job.
+   */
+  public struct Credentials: Sendable {
+    public let accessKey: String
+    public let secretKey: String
+    public let cookies: [String: String]
+
+    public init(
+      accessKey: String,
+      secretKey: String,
+      cookies: [String: String] = [:]
+    ) {
+      self.accessKey = accessKey
+      self.secretKey = secretKey
+      self.cookies = cookies
+    }
+
+    /// The `Authorization` header value for these credentials
+    var authorizationHeaderValue: String {
+      "LOW \(accessKey):\(secretKey)"
+    }
+
+    /// The `Cookie` header value, or nil when there are no cookies
+    var cookieHeaderValue: String? {
+      guard !cookies.isEmpty else { return nil }
+      return cookies
+        .sorted { $0.key < $1.key }
+        .map { "\($0.key)=\($0.value)" }
+        .joined(separator: "; ")
+    }
+  }
+
+  /**
+   The result of a successful `login(email:password:)` call.
+
+   Carries the account's S3 keys and session cookies as `Credentials`, ready
+   to pass to `InternetArchive(urlGenerator:urlSession:credentials:)`.
+   */
+  public struct Account: Sendable {
+    public let credentials: Credentials
+    public let screenname: String?
+
+    public init(credentials: Credentials, screenname: String?) {
+      self.credentials = credentials
+      self.screenname = screenname
+    }
+  }
+
+  /// The xauthn login response envelope, e.g.
+  /// `{"success": true, "values": {"s3": {...}, "cookies": {...}, "screenname": "..."}}`
+  /// or `{"success": false, "values": {"reason": "..."}}`.
+  struct XAuthnEnvelope: Decodable {
+    struct Values: Decodable {
+      struct S3: Decodable {
+        let access: String?
+        let secret: String?
+      }
+      let s3: S3?
+      let cookies: [String: String]?
+      let screenname: String?
+      let reason: String?
+    }
+    let success: Bool
+    let values: Values?
+  }
+}

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -178,6 +178,37 @@ public protocol InternetArchiveProtocol {
   )
 
   /**
+   Log in to archive.org and fetch the account's S3 keys and cookies
+
+   Wraps the xauthn login endpoint. Stateless: stores nothing and holds the
+   password only for the one request; persisting the returned credentials is
+   the caller's job. Pasting keys from https://archive.org/account/s3.php
+   skips passwords entirely.
+
+   - parameters:
+   - email: The account email
+   - password: The account password
+   - returns: InternetArchive.Account
+   */
+  func login(
+    email: String,
+    password: String
+  ) async throws -> InternetArchive.Account
+
+  /**
+   Log in to archive.org and fetch the account's S3 keys and cookies
+
+   - parameters:
+   - email: The account email
+   - password: The account password
+   - returns: Result<InternetArchive.Account, Error>
+   */
+  func login(
+    email: String,
+    password: String
+  ) async -> Result<InternetArchive.Account, Error>
+
+  /**
    Fetch a single item from the Internet Archive
 
    - parameters:
@@ -217,6 +248,7 @@ public protocol InternetArchiveProtocol {
 public protocol InternetArchiveURLGeneratorProtocol {
   func generateItemImageUrl(itemIdentifier: String) -> URL?
   func generateMetadataUrl(identifier: String) -> URL?
+  func generateXauthnUrl(operation: String) -> URL?
   func generateDownloadUrl(itemIdentifier: String, fileName: String) -> URL?
   func generateSearchUrl(
     query: InternetArchiveURLStringProtocol,
@@ -299,6 +331,23 @@ extension InternetArchiveProtocol {
     query: InternetArchiveURLStringProtocol
   ) async throws -> Int {
     let result: Result<Int, Error> = await scrapeTotal(query: query)
+    switch result {
+    case .success(let success):
+      return success
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  /** @inheritdoc */
+  public func login(
+    email: String,
+    password: String
+  ) async throws -> InternetArchive.Account {
+    let result: Result<InternetArchive.Account, Error> = await login(
+      email: email,
+      password: password
+    )
     switch result {
     case .success(let success):
       return success

--- a/InternetArchiveKit/InternetArchiveURLGenerator.swift
+++ b/InternetArchiveKit/InternetArchiveURLGenerator.swift
@@ -169,6 +169,21 @@ extension InternetArchive {
       return urlComponents.url
     }
 
+    /**
+     Generate an xauthn (`/services/xauthn/`) url
+
+     - parameters:
+       - operation: The xauthn operation, e.g. `login`
+
+     - returns: Optional xauthn `URL`
+     */
+    public func generateXauthnUrl(operation: String) -> URL? {
+      var urlComponents: URLComponents = getBaseUrlComponents()
+      urlComponents.path = "/services/xauthn/"
+      urlComponents.queryItems = [URLQueryItem(name: "op", value: operation)]
+      return urlComponents.url
+    }
+
     private func getBaseUrlComponents() -> URLComponents {
       var urlComponents: URLComponents = URLComponents()
       urlComponents.scheme = scheme

--- a/InternetArchiveKitTests/AuthTests.swift
+++ b/InternetArchiveKitTests/AuthTests.swift
@@ -1,0 +1,163 @@
+//
+//  AuthTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 7/17/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+import URLSessionMock
+@testable import InternetArchiveKit
+
+class AuthTests: XCTestCase {
+
+  private func searchSetup(
+    credentials: InternetArchive.Credentials?
+  ) -> (archive: InternetArchive, endpoint: BasicEndpointMock, query: InternetArchive.Query)? {
+    let urlGenerator = InternetArchive.URLGenerator()
+    let query: InternetArchive.Query = InternetArchive.Query(
+      clauses: ["collection": "etree"])
+    guard
+      let url = urlGenerator.generateSearchUrl(
+        query: query, page: 1, rows: 10, fields: [], sortFields: [],
+        additionalQueryParams: [])
+    else { return nil }
+
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: Data("{}".utf8), headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator,
+      urlSession: URLSession.mock,
+      credentials: credentials
+    )
+    return (archive, endpoint, query)
+  }
+
+  func testAuthorizationHeaderAttached() async {
+    let credentials = InternetArchive.Credentials(
+      accessKey: "accessfoo",
+      secretKey: "secretbar",
+      cookies: ["logged-in-user": "foo%40example.com", "logged-in-sig": "xyz"]
+    )
+    guard let (archive, endpoint, query) = searchSetup(credentials: credentials) else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    _ = await archive.search(query: query, page: 1, rows: 10, fields: [], sortFields: [])
+
+    let request = endpoint.requests.first
+    XCTAssertEqual(
+      request?.value(forHTTPHeaderField: "Authorization"),
+      "LOW accessfoo:secretbar"
+    )
+    XCTAssertEqual(
+      request?.value(forHTTPHeaderField: "Cookie"),
+      "logged-in-sig=xyz; logged-in-user=foo%40example.com"
+    )
+  }
+
+  func testNoAuthorizationHeaderWithoutCredentials() async {
+    guard let (archive, endpoint, query) = searchSetup(credentials: nil) else {
+      XCTFail("error generating search url")
+      return
+    }
+
+    _ = await archive.search(query: query, page: 1, rows: 10, fields: [], sortFields: [])
+
+    XCTAssertNil(endpoint.requests.first?.value(forHTTPHeaderField: "Authorization"))
+    XCTAssertNil(endpoint.requests.first?.value(forHTTPHeaderField: "Cookie"))
+  }
+
+  func testGenerateXauthnUrl() {
+    let generator = InternetArchive.URLGenerator()
+    XCTAssertEqual(
+      generator.generateXauthnUrl(operation: "login")?.absoluteString,
+      "https://archive.org/services/xauthn/?op=login"
+    )
+  }
+
+  func testFormEncode() {
+    let data = InternetArchive.formEncode([
+      ("email", "foo+bar@example.com"),
+      ("password", "p@ss word&=1"),
+    ])
+    XCTAssertEqual(
+      data.flatMap { String(data: $0, encoding: .utf8) },
+      "email=foo%2Bbar%40example.com&password=p%40ss%20word%26%3D1"
+    )
+  }
+
+  func testLoginSuccess() async {
+    let json = """
+      {
+        "success": true,
+        "values": {
+          "s3": {"access": "accessfoo", "secret": "secretbar"},
+          "cookies": {"logged-in-user": "foo%40example.com", "logged-in-sig": "xyz"},
+          "screenname": "foo"
+        },
+        "version": 1
+      }
+    """
+    let urlGenerator = InternetArchive.URLGenerator()
+    guard let url = urlGenerator.generateXauthnUrl(operation: "login") else {
+      XCTFail("error generating xauthn url")
+      return
+    }
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: Data(json.utf8), headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    let result = await archive.login(email: "foo@example.com", password: "hunter2")
+
+    switch result {
+    case .success(let account):
+      XCTAssertEqual(account.credentials.accessKey, "accessfoo")
+      XCTAssertEqual(account.credentials.secretKey, "secretbar")
+      XCTAssertEqual(account.credentials.cookies["logged-in-sig"], "xyz")
+      XCTAssertEqual(account.screenname, "foo")
+    case .failure(let error):
+      XCTFail("error, \(error.localizedDescription)")
+    }
+
+    let request = endpoint.requests.first
+    XCTAssertEqual(request?.httpMethod, "POST")
+    XCTAssertEqual(
+      request?.value(forHTTPHeaderField: "Content-Type"),
+      "application/x-www-form-urlencoded"
+    )
+  }
+
+  func testLoginFailureSurfacesReason() async {
+    let json = """
+      {"success": false, "values": {"reason": "bad credentials"}, "version": 1}
+    """
+    let urlGenerator = InternetArchive.URLGenerator()
+    guard let url = urlGenerator.generateXauthnUrl(operation: "login") else {
+      XCTFail("error generating xauthn url")
+      return
+    }
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: Data(json.utf8), headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator, urlSession: URLSession.mock)
+    let result = await archive.login(email: "foo@example.com", password: "wrong")
+
+    switch result {
+    case .success:
+      XCTFail("expected a failure")
+    case .failure(let error):
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.apiError(message: "bad credentials")
+      )
+    }
+  }
+}

--- a/InternetArchiveKitTests/InternetArchiveKitTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveKitTests.swift
@@ -28,6 +28,10 @@ class InternetArchiveKitTests: XCTestCase {
       return nil
     }
 
+    func generateXauthnUrl(operation: String) -> URL? {
+      return nil
+    }
+
     func generateDownloadUrl(itemIdentifier: String, fileName: String) -> URL? {
       return nil
     }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ let result = await archive.scrapeTotal(query: query)
 // result == .success(9250)
 ```
 
+## Authentication
+
+Most of the library needs no credentials. For endpoints that do, pass an S3 key pair (from [archive.org/account/s3.php](https://archive.org/account/s3.php)) and requests get an `Authorization: LOW access:secret` header:
+
+```swift
+let credentials = InternetArchive.Credentials(accessKey: "...", secretKey: "...")
+let archive = InternetArchive(credentials: credentials)
+```
+
+You can also fetch keys programmatically with `login(email:password:)`, which wraps archive.org's xauthn endpoint. It's stateless: the password only exists for that one call and nothing is stored. Persisting the returned credentials (for example in the Keychain) is your app's job:
+
+```swift
+let result = await InternetArchive().login(email: "you@example.com", password: "...")
+if case .success(let account) = result {
+  let archive = InternetArchive(credentials: account.credentials)
+}
+```
+
 ## Limitations
 
 Currently, InternetArchiveKit is read-only and does not have support for all of Internet Archive's data. Pull requests are welcome!


### PR DESCRIPTION
Closes #36. Unblocks the write APIs and the Changes API in #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf