### PR TITLE
Replace ZippyJSON with Foundation's JSONDecoder

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ZippyJSON
 import os.log
 
 let logSubsystemId: String = "engineering.astral.internetarchivekit"
@@ -55,8 +54,8 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
 
   private let urlGenerator: InternetArchiveURLGeneratorProtocol
 
-  private let jsonDecoder: ZippyJSONDecoder = {
-    let decoder = ZippyJSONDecoder()
+  private let jsonDecoder: JSONDecoder = {
+    let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     return decoder
   }()

--- a/InternetArchiveKitTests/DateParserTests.swift
+++ b/InternetArchiveKitTests/DateParserTests.swift
@@ -12,7 +12,7 @@ import XCTest
 // formatters — ISO8601 first, then a series of DateFormatter patterns — so that IA
 // metadata dates, which arrive in several shapes, all decode to a Date. These tests
 // drive the parser directly (no JSON layer) to pin every supported shape and the nil
-// cases, isolating the parser from the ModelField / ZippyJSON decode path.
+// cases, isolating the parser from the ModelField decode path.
 class DateParserTests: XCTestCase {
   private let parser = DateParser.shared
 

--- a/InternetArchiveKitTests/FileTests.swift
+++ b/InternetArchiveKitTests/FileTests.swift
@@ -7,7 +7,6 @@
 //
 
 import XCTest
-import ZippyJSON
 import InternetArchiveKit
 
 class FileTests: XCTestCase {
@@ -43,7 +42,7 @@ class FileTests: XCTestCase {
     }
     """#.data(using: .utf8)!
 
-    let file = try ZippyJSONDecoder().decode(InternetArchive.File.self, from: json)
+    let file = try JSONDecoder().decode(InternetArchive.File.self, from: json)
     XCTAssertEqual(file.name, "frtr100312d1_01_Ripple.flac")
     XCTAssertEqual(file.private?.value, true)
   }
@@ -56,7 +55,7 @@ class FileTests: XCTestCase {
     }
     """#.data(using: .utf8)!
 
-    let file = try ZippyJSONDecoder().decode(InternetArchive.File.self, from: json)
+    let file = try JSONDecoder().decode(InternetArchive.File.self, from: json)
     XCTAssertNil(file.private)
   }
 

--- a/InternetArchiveKitTests/ModelFieldTests.swift
+++ b/InternetArchiveKitTests/ModelFieldTests.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 @testable import InternetArchiveKit
-import ZippyJSON
 
 class ModelFieldTests: XCTestCase {
 
@@ -35,7 +34,7 @@ class ModelFieldTests: XCTestCase {
 
     measure {
       for _ in 0..<1000 {
-        _ = try? ZippyJSONDecoder().decode(Foo.self, from: data)
+        _ = try? JSONDecoder().decode(Foo.self, from: data)
       }
     }
   }
@@ -55,7 +54,7 @@ class ModelFieldTests: XCTestCase {
 
     measure {
       for _ in 0..<1000 {
-        _ = try? ZippyJSONDecoder().decode(Foo.self, from: data)
+        _ = try? JSONDecoder().decode(Foo.self, from: data)
       }
     }
   }
@@ -83,7 +82,7 @@ class ModelFieldTests: XCTestCase {
     }
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
       XCTAssertEqual(results.foo.values, ["bar"])
       XCTAssertEqual(results.foo.value, "bar")
 
@@ -108,7 +107,7 @@ class ModelFieldTests: XCTestCase {
     }
 
     do {
-      _ = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      _ = try JSONDecoder().decode(Foo.self, from: data)
       XCTFail("This should not have succeeded")
     } catch {
       XCTAssertTrue(error is Swift.DecodingError)
@@ -142,7 +141,7 @@ class ModelFieldTests: XCTestCase {
     }
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
       XCTAssertEqual(results.foo.values, [1])
       XCTAssertEqual(results.foo.value, 1)
 
@@ -188,7 +187,7 @@ class ModelFieldTests: XCTestCase {
     }
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
       XCTAssertEqual(results.foo.values, [true])
       XCTAssertEqual(results.foo.value, true)
 
@@ -232,7 +231,7 @@ class ModelFieldTests: XCTestCase {
     }
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
       XCTAssertEqual(results.good.values, [1.2, 2.3])
       XCTAssertEqual(results.good.value, 1.2)
 
@@ -312,7 +311,7 @@ class ModelFieldTests: XCTestCase {
     let comparisonISODateTimeZoneOffset2 = isoFormatter.date(from: "2018-11-15T15:23:11+04:00")
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
 
       XCTAssertEqual(results.year.value, comparisonYear)
       XCTAssertEqual(results.yearBracket.value, comparisonYearBracket)
@@ -354,7 +353,7 @@ class ModelFieldTests: XCTestCase {
     let comparisonUrl = URL(string: "http://yondermountainstringband.com")
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
 
       XCTAssertEqual(results.foo.values, [comparisonUrl])
       XCTAssertEqual(results.foo.value, comparisonUrl)
@@ -419,7 +418,7 @@ class ModelFieldTests: XCTestCase {
     let comparisonBadString = TimeInterval(0)
 
     do {
-      let results: Foo = try ZippyJSONDecoder().decode(Foo.self, from: data)
+      let results: Foo = try JSONDecoder().decode(Foo.self, from: data)
 
       XCTAssertEqual(results.decimal.value, comparisonDecimal)
       XCTAssertEqual(results.intString.value, comparisonIntString)

--- a/InternetArchiveKitTests/ReviewTests.swift
+++ b/InternetArchiveKitTests/ReviewTests.swift
@@ -7,7 +7,6 @@
 //
 
 import XCTest
-import ZippyJSON
 import InternetArchiveKit
 
 class ReviewTests: XCTestCase {
@@ -28,20 +27,8 @@ class ReviewTests: XCTestCase {
   }
   """#.data(using: .utf8)!
 
-  func testDecodesReviewerItemnameWithZippyJSON() throws {
+  func testDecodesReviewerItemname() throws {
     // Same decoder configuration as InternetArchive.swift
-    let decoder = ZippyJSONDecoder()
-    decoder.keyDecodingStrategy = .convertFromSnakeCase
-
-    let review = try decoder.decode(InternetArchive.Review.self, from: reviewJson)
-    XCTAssertEqual(review.reviewer, "HughMcQToo")
-    XCTAssertEqual(review.stars?.value, 5)
-    XCTAssertEqual(review.reviewerItemname, "@hughmcqtoo")
-  }
-
-  func testDecodesReviewerItemnameWithFoundationJSONDecoder() throws {
-    // ZippyJSONDecoder falls back to Foundation's JSONDecoder on unsupported
-    // platforms, so both decoders must agree.
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
@@ -55,7 +42,7 @@ class ReviewTests: XCTestCase {
   // exercised without compiler warnings.
   @available(*, deprecated)
   func testDeprecatedSnakeCaseSpellingsStillWork() throws {
-    let decoder = ZippyJSONDecoder()
+    let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
     let review = try decoder.decode(InternetArchive.Review.self, from: reviewJson)

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,24 +17,6 @@
         "revision" : "128e48ecdea3508b1264d31443a83e718caa8f7e",
         "version" : "0.1.0"
       }
-    },
-    {
-      "identity" : "zippyjson",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/michaeleisel/ZippyJSON",
-      "state" : {
-        "revision" : "ddbbc024ba5a826f9676035a0a090a0bc2d40755",
-        "version" : "1.2.15"
-      }
-    },
-    {
-      "identity" : "zippyjsoncfamily",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/michaeleisel/ZippyJSONCFamily",
-      "state" : {
-        "revision" : "c1c0f88977359ea85b81e128b2d988e8250dfdae",
-        "version" : "1.2.14"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,13 @@ let package = Package(
     .library(name: "InternetArchiveKit", targets: ["InternetArchiveKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/michaeleisel/ZippyJSON", .upToNextMajor(from: "1.2.4")),
     .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.2.0")),
     .package(url: "https://github.com/azsn/URLSessionMock", .upToNextMajor(from: "0.1.0")),
   ],
   targets: [
     .target(
       name: "InternetArchiveKit",
-      dependencies: ["JJLISO8601DateFormatter", "ZippyJSON"],
+      dependencies: ["JJLISO8601DateFormatter"],
       path: "InternetArchiveKit",
       resources: [
         .process("PrivacyInfo.xcprivacy")]


### PR DESCRIPTION
Closes #29. Went with option C (drop unconditionally): the floor moves to iOS 15 in #59 anyway, the example app is iOS 17, and this client has no hot-loop decoding. Merge order note: conflicts trivially with the other InternetArchive.swift PRs on the decoder property lines; whichever lands last needs a quick main merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf