### PR TITLE
Add Item Metadata write support

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -185,6 +185,56 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   }
 
   /** @inheritdoc */
+  public func modifyMetadata(
+    identifier: String,
+    target: String = "metadata",
+    patch: [MetadataPatchOperation]
+  ) async -> Result<MetadataWriteResult, Error> {
+    guard let credentials = credentials else {
+      return .failure(InternetArchiveError.missingCredentials)
+    }
+    guard
+      let metadataUrl: URL = urlGenerator.generateMetadataUrl(
+        identifier: identifier
+      )
+    else {
+      return .failure(InternetArchiveError.invalidUrl)
+    }
+
+    let patchData: Data
+    do {
+      patchData = try JSONEncoder().encode(patch)
+    } catch {
+      return .failure(error)
+    }
+
+    // credentials travel in the POST body, so nothing in this path is logged
+    var request = URLRequest(url: metadataUrl)
+    request.httpMethod = "POST"
+    request.setValue(
+      "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    request.httpBody = Self.formEncode([
+      ("-target", target),
+      ("-patch", String(decoding: patchData, as: UTF8.self)),
+      ("access", credentials.accessKey),
+      ("secret", credentials.secretKey),
+    ])
+
+    do {
+      let (data, _) = try await urlSession.data(for: request)
+      let envelope: MetadataWriteEnvelope = try decodeResponse(data)
+      guard envelope.success == true else {
+        let message = envelope.error ?? "metadata write failed"
+        return .failure(InternetArchiveError.apiError(message: message))
+      }
+      return .success(
+        MetadataWriteResult(taskId: envelope.taskId, log: envelope.log))
+    } catch {
+      return .failure(error)
+    }
+  }
+
+  /** @inheritdoc */
   public func scrapeTotal(
     query: InternetArchiveURLStringProtocol
   ) async -> Result<Int, Error> {

--- a/InternetArchiveKit/InternetArchiveErrors.swift
+++ b/InternetArchiveKit/InternetArchiveErrors.swift
@@ -28,6 +28,10 @@ extension InternetArchive {
     /// `identifier`, if it appears in a scrape sort, to be the last sort field.
     /// `message` explains what to fix.
     case invalidSortFields(message: String)
+
+    /// The request needs credentials and this `InternetArchive` instance was
+    /// created without them. Pass `Credentials` at init.
+    case missingCredentials
   }
 }
 
@@ -40,6 +44,8 @@ extension InternetArchive.InternetArchiveError: LocalizedError {
       return "Internet Archive API error: \(message)"
     case .invalidSortFields(let message):
       return "Invalid sort fields: \(message)"
+    case .missingCredentials:
+      return "This request requires credentials"
     }
   }
 }

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -140,6 +140,40 @@ public protocol InternetArchiveProtocol {
   )
 
   /**
+   Write metadata to an Internet Archive item
+
+   Applies an RFC 6902 JSON Patch to the item's `target` (usually
+   `metadata`). Requires credentials. The write is queued as a catalog task;
+   the returned result carries the task id and log url.
+
+   - parameters:
+   - identifier: The item identifier
+   - target: The patch destination, e.g. `metadata` or `files/{filename}`
+   - patch: The patch operations to apply
+   - returns: InternetArchive.MetadataWriteResult
+   */
+  func modifyMetadata(
+    identifier: String,
+    target: String,
+    patch: [InternetArchive.MetadataPatchOperation]
+  ) async throws -> InternetArchive.MetadataWriteResult
+
+  /**
+   Write metadata to an Internet Archive item
+
+   - parameters:
+   - identifier: The item identifier
+   - target: The patch destination, e.g. `metadata` or `files/{filename}`
+   - patch: The patch operations to apply
+   - returns: Result<InternetArchive.MetadataWriteResult, Error>
+   */
+  func modifyMetadata(
+    identifier: String,
+    target: String,
+    patch: [InternetArchive.MetadataPatchOperation]
+  ) async -> Result<InternetArchive.MetadataWriteResult, Error>
+
+  /**
    Count the results of a Scrape API query
 
    Returns the total number of matching items without fetching any of them
@@ -318,6 +352,25 @@ extension InternetArchiveProtocol {
       pagination: pagination
     )
 
+    switch result {
+    case .success(let success):
+      return success
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  /** @inheritdoc */
+  public func modifyMetadata(
+    identifier: String,
+    target: String,
+    patch: [InternetArchive.MetadataPatchOperation]
+  ) async throws -> InternetArchive.MetadataWriteResult {
+    let result: Result<InternetArchive.MetadataWriteResult, Error> = await modifyMetadata(
+      identifier: identifier,
+      target: target,
+      patch: patch
+    )
     switch result {
     case .success(let success):
       return success

--- a/InternetArchiveKit/Models/MetadataWrite.swift
+++ b/InternetArchiveKit/Models/MetadataWrite.swift
@@ -1,0 +1,97 @@
+//
+//  MetadataWrite.swift
+//  InternetArchiveKit
+//
+//  Created by Jason Buckner on 7/17/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import Foundation
+
+extension InternetArchive {
+  /**
+   One RFC 6902 JSON Patch operation for a `modifyMetadata()` call.
+
+   Paths are JSON Pointers relative to the target, e.g. `/venue` for the
+   venue field of an item's metadata.
+
+   ### Example Usage:
+   ```
+   let patch: [InternetArchive.MetadataPatchOperation] = [
+     .replace(path: "/venue", value: .string("Red Rocks")),
+     .add(path: "/subject", value: .strings(["Live concert", "SBD"])),
+     .remove(path: "/notes"),
+   ]
+   ```
+   */
+  public enum MetadataPatchOperation: Sendable, Encodable {
+    case add(path: String, value: MetadataPatchValue)
+    case replace(path: String, value: MetadataPatchValue)
+    case remove(path: String)
+
+    enum CodingKeys: String, CodingKey {
+      case op
+      case path
+      case value
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      switch self {
+      case .add(let path, let value):
+        try container.encode("add", forKey: .op)
+        try container.encode(path, forKey: .path)
+        try container.encode(value, forKey: .value)
+      case .replace(let path, let value):
+        try container.encode("replace", forKey: .op)
+        try container.encode(path, forKey: .path)
+        try container.encode(value, forKey: .value)
+      case .remove(let path):
+        try container.encode("remove", forKey: .op)
+        try container.encode(path, forKey: .path)
+      }
+    }
+  }
+
+  /// A metadata value in a patch: a single string or a list of strings, the
+  /// two shapes Internet Archive metadata fields take.
+  public enum MetadataPatchValue: Sendable, Encodable {
+    case string(String)
+    case strings([String])
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      switch self {
+      case .string(let value):
+        try container.encode(value)
+      case .strings(let values):
+        try container.encode(values)
+      }
+    }
+  }
+
+  /**
+   The result of a successful `modifyMetadata()` call.
+
+   The write is queued as a catalog task; `taskId` and `log` point at it.
+   */
+  public struct MetadataWriteResult: Sendable {
+    public let taskId: Int?
+    public let log: String?
+
+    public init(taskId: Int?, log: String?) {
+      self.taskId = taskId
+      self.log = log
+    }
+  }
+
+  /// The metadata write response envelope, e.g.
+  /// `{"success": true, "task_id": 123, "log": "…"}` or
+  /// `{"success": false, "error": "…"}`.
+  struct MetadataWriteEnvelope: Decodable {
+    let success: Bool?
+    let taskId: Int?
+    let log: String?
+    let error: String?
+  }
+}

--- a/InternetArchiveKitTests/MetadataWriteTests.swift
+++ b/InternetArchiveKitTests/MetadataWriteTests.swift
@@ -1,0 +1,126 @@
+//
+//  MetadataWriteTests.swift
+//  InternetArchiveKitTests
+//
+//  Created by Jason Buckner on 7/17/26.
+//  Copyright © 2026 Jason Buckner. All rights reserved.
+//
+
+import XCTest
+import URLSessionMock
+@testable import InternetArchiveKit
+
+class MetadataWriteTests: XCTestCase {
+
+  private let credentials = InternetArchive.Credentials(
+    accessKey: "accessfoo", secretKey: "secretbar")
+
+  func testPatchOperationEncoding() throws {
+    let patch: [InternetArchive.MetadataPatchOperation] = [
+      .replace(path: "/venue", value: .string("Red Rocks")),
+      .add(path: "/subject", value: .strings(["Live concert", "SBD"])),
+      .remove(path: "/notes"),
+    ]
+    // key order within an operation is unordered JSON; sort for a stable comparison
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let data = try encoder.encode(patch)
+    let json = String(decoding: data, as: UTF8.self)
+    XCTAssertEqual(
+      json,
+      #"[{"op":"replace","path":"\/venue","value":"Red Rocks"},"#
+        + #"{"op":"add","path":"\/subject","value":["Live concert","SBD"]},"#
+        + #"{"op":"remove","path":"\/notes"}]"#
+    )
+  }
+
+  func testModifyMetadataRequiresCredentials() async {
+    let archive = InternetArchive(
+      urlGenerator: InternetArchive.URLGenerator(),
+      urlSession: URLSession.mock
+    )
+    let result = await archive.modifyMetadata(
+      identifier: "foo", patch: [.remove(path: "/notes")])
+    switch result {
+    case .success:
+      XCTFail("expected a failure")
+    case .failure(let error):
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.missingCredentials
+      )
+    }
+  }
+
+  func testModifyMetadataSuccess() async {
+    let json = """
+      {"success": true, "task_id": 2391928033, "log": "https://catalogd.archive.org/log/2391928033"}
+    """
+    let urlGenerator = InternetArchive.URLGenerator()
+    guard let url = urlGenerator.generateMetadataUrl(identifier: "foo") else {
+      XCTFail("error generating metadata url")
+      return
+    }
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: Data(json.utf8), headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator,
+      urlSession: URLSession.mock,
+      credentials: credentials
+    )
+    let result = await archive.modifyMetadata(
+      identifier: "foo",
+      patch: [.replace(path: "/venue", value: .string("Red Rocks"))]
+    )
+
+    switch result {
+    case .success(let write):
+      XCTAssertEqual(write.taskId, 2391928033)
+      XCTAssertEqual(write.log, "https://catalogd.archive.org/log/2391928033")
+    case .failure(let error):
+      XCTFail("error, \(error.localizedDescription)")
+    }
+
+    let request = endpoint.requests.first
+    XCTAssertEqual(request?.httpMethod, "POST")
+    XCTAssertEqual(
+      request?.value(forHTTPHeaderField: "Content-Type"),
+      "application/x-www-form-urlencoded"
+    )
+  }
+
+  func testModifyMetadataFailureSurfacesError() async {
+    let json = """
+      {"success": false, "error": "no write access to this item"}
+    """
+    let urlGenerator = InternetArchive.URLGenerator()
+    guard let url = urlGenerator.generateMetadataUrl(identifier: "foo") else {
+      XCTFail("error generating metadata url")
+      return
+    }
+    let endpoint = BasicEndpointMock(
+      status: 200, url: url, body: Data(json.utf8), headers: nil, error: nil)
+    URLSession.mockEndpoints = [url: endpoint]
+
+    let archive = InternetArchive(
+      urlGenerator: urlGenerator,
+      urlSession: URLSession.mock,
+      credentials: credentials
+    )
+    let result = await archive.modifyMetadata(
+      identifier: "foo", patch: [.remove(path: "/notes")])
+
+    switch result {
+    case .success:
+      XCTFail("expected a failure")
+    case .failure(let error):
+      XCTAssertEqual(
+        error as? InternetArchive.InternetArchiveError,
+        InternetArchive.InternetArchiveError.apiError(
+          message: "no write access to this item")
+      )
+    }
+  }
+}


### PR DESCRIPTION
Closes #82. Part of #35, stacked on #74 (auth); merge that first and this retargets to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u2FT1T8yYQsEztyKg6UGf