### PR TITLE
Adopt Swift 6 language mode

### DIFF
--- a/InternetArchiveKit/InternetArchive.swift
+++ b/InternetArchiveKit/InternetArchive.swift
@@ -96,7 +96,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     rows: Int,
     fields: [String]? = nil,
     sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
-    completion: @escaping (InternetArchive.SearchResponse?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.SearchResponse?, Error?) -> Void
   ) {
     Task {
       let results: Result<SearchResponse, Error> = await search(
@@ -155,7 +155,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
     fields: [String]? = nil,
     sortFields: [InternetArchiveURLQueryItemProtocol]? = nil,
     pagination: ScrapePagination? = nil,
-    completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.ScrapeResponse?, Error?) -> Void
   ) {
     Task {
       let results: Result<ScrapeResponse, Error> = await scrape(
@@ -203,7 +203,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   @available(*, deprecated, message: "Use the async version instead")
   public func scrapeTotal(
     query: InternetArchiveURLStringProtocol,
-    completion: @escaping (Int?, Error?) -> Void
+    completion: @escaping @Sendable (Int?, Error?) -> Void
   ) {
     Task {
       let result: Result<Int, Error> = await scrapeTotal(query: query)
@@ -236,7 +236,7 @@ public final class InternetArchive: InternetArchiveProtocol, @unchecked Sendable
   @available(*, deprecated, message: "Use the async version instead")
   public func itemDetail(
     identifier: String,
-    completion: @escaping (InternetArchive.Item?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.Item?, Error?) -> Void
   ) {
     Task {
       let results: Result<Item, Error> = await itemDetail(

--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -72,7 +72,7 @@ public protocol InternetArchiveProtocol {
     rows: Int,
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
-    completion: @escaping (InternetArchive.SearchResponse?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.SearchResponse?, Error?) -> Void
   )
 
   /**
@@ -138,7 +138,7 @@ public protocol InternetArchiveProtocol {
     fields: [String]?,
     sortFields: [InternetArchiveURLQueryItemProtocol]?,
     pagination: InternetArchive.ScrapePagination?,
-    completion: @escaping (InternetArchive.ScrapeResponse?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.ScrapeResponse?, Error?) -> Void
   )
 
   /**
@@ -177,7 +177,7 @@ public protocol InternetArchiveProtocol {
   @available(*, deprecated, message: "Use the async version instead")
   func scrapeTotal(
     query: InternetArchiveURLStringProtocol,
-    completion: @escaping (Int?, Error?) -> Void
+    completion: @escaping @Sendable (Int?, Error?) -> Void
   )
 
   /**
@@ -213,7 +213,7 @@ public protocol InternetArchiveProtocol {
   @available(*, deprecated, message: "Use the async version instead")
   func itemDetail(
     identifier: String,
-    completion: @escaping (InternetArchive.Item?, Error?) -> Void
+    completion: @escaping @Sendable (InternetArchive.Item?, Error?) -> Void
   )
 }
 

--- a/InternetArchiveKit/Models/Fields/DateParser.swift
+++ b/InternetArchiveKit/Models/Fields/DateParser.swift
@@ -21,7 +21,7 @@ extension JJLISO8601DateFormatter: DateParserProtocol {}
 /// The shared instance is safe to use from concurrent decodes: `parsers` is
 /// immutable after init, and both `DateFormatter` and
 /// `JJLISO8601DateFormatter` are documented thread-safe.
-final class DateParser {
+final class DateParser: @unchecked Sendable {
   static let shared: DateParser = DateParser()
 
   func date(from string: String) -> Date? {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -26,7 +26,10 @@ let package = Package(
     .testTarget(
       name: "InternetArchiveKitTests",
       dependencies: ["InternetArchiveKit", "JJLISO8601DateFormatter", "URLSessionMock"],
-      path: "InternetArchiveKitTests"
+      path: "InternetArchiveKitTests",
+      // URLSessionMock exposes a mutable static (`mockEndpoints`) that isn't
+      // Sendable; keep the tests in Swift 5 mode while the library is Swift 6.
+      swiftSettings: [.swiftLanguageMode(.v5)]
     )
   ]
 )


### PR DESCRIPTION
Moves the package to `swift-tools-version: 6.0` (Swift 6 language mode / complete data-race checking). The models already conform to `Sendable`, so this is a small pass — no API-shape changes to the data types.

## Changes
- **DateParser** → `@unchecked Sendable`. It's immutable after init and its `DateFormatter` / `JJLISO8601DateFormatter` parsers are documented thread-safe (already called out in the type's doc comment).
- **Deprecated completion-handler APIs**: they bridge into a `Task { … completion(…) }`, so the completion closures must be `@Sendable` — annotated on both `InternetArchiveProtocol` and the `InternetArchive` impl. Minor source-compat note: callers of these already-deprecated variants that pass a closure capturing non-Sendable state will see a warning.
- **Test target** kept in Swift 5 mode (`swiftLanguageMode(.v5)`): URLSessionMock exposes a mutable static (`mockEndpoints`) that isn't Sendable. The library itself is Swift 6.

## Testing
`swift build` clean under Swift 6. `swift test`: 123/125 pass; the 2 failures are the live-archive.org `scrapeTotal` tests, which fail on `main` too (they assert a hardcoded count against the real API).

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
