### PR TITLE
Make InternetArchiveProtocol refine Sendable

### DIFF
--- a/InternetArchiveKit/InternetArchiveProtocols.swift
+++ b/InternetArchiveKit/InternetArchiveProtocols.swift
@@ -8,8 +8,14 @@
 
 import Foundation
 
-/// A protocol to which the main `InternetArchive` class conforms
-public protocol InternetArchiveProtocol {
+/// A protocol to which the main `InternetArchive` class conforms.
+///
+/// Refines `Sendable`: the client is a stateless request builder over a
+/// `URLSession`, safe to share across concurrency domains (the concrete
+/// `InternetArchive` is `@unchecked Sendable`). This lets callers hold an
+/// `any InternetArchiveProtocol` inside an actor or send it across isolation
+/// boundaries.
+public protocol InternetArchiveProtocol: Sendable {
   /**
    Search the Internet Archive
 


### PR DESCRIPTION
Closes #94

Refines `InternetArchiveProtocol: Sendable` so callers can hold an `any InternetArchiveProtocol` inside an actor or send it across isolation boundaries. The concrete `InternetArchive` is already `@unchecked Sendable`, so no conformers change. Main target and tests both build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf7er8mrabacGCMtLjd6mQ