### PR TITLE
Fix #96 - Don't escape the ES operator characters that archive.org rejects

### DIFF
--- a/InternetArchiveKit/InternetArchiveQuery.swift
+++ b/InternetArchiveKit/InternetArchiveQuery.swift
@@ -127,10 +127,14 @@ extension InternetArchive {
       return "\(booleanOperator.rawValue)\(fieldKey)\(finalValue)"
     }
 
-    /// Lucene syntax characters that get backslash-escaped in values. `*` and
-    /// `?` are deliberately absent so wildcard searches keep working.
+    /// Lucene syntax characters that get backslash-escaped in non-exactMatch
+    /// values. The query operators `+ - & | "` and the wildcards `* ?` are
+    /// deliberately absent: archive.org's Elasticsearch backend rejects the
+    /// escaped forms of the operators (`\-`, `\+`, `\&`, `\|`, `\"` come back
+    /// as a backend error) and they don't need escaping mid-value there, while
+    /// `* ?` stay raw so wildcard searches keep working.
     private static let luceneSpecialCharacters: Set<Character> = [
-      "+", "-", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", ":", "\\", "/",
+      "(", ")", "{", "}", "[", "]", "^", "~", ":", "\\", "/", "!",
     ]
 
     static func escapingLuceneSyntax(in value: String) -> String {

--- a/InternetArchiveKitTests/InternetArchiveQueryTests.swift
+++ b/InternetArchiveKitTests/InternetArchiveQueryTests.swift
@@ -63,12 +63,21 @@ class InternetArchiveQueryTests: XCTestCase {
     XCTAssertEqual(clause.asURLString, "venue:(foo fest \\[bar stage\\])")
   }
 
-  func testQueryClauseEscapesEveryLuceneSpecialCharacter() {
+  func testQueryClauseEscapesParserSpecialCharacters() {
     let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
-      field: "foo", value: "a+b-c&d|e!f(g)h{i}j[k]l^m\"n~o:p\\q/r")
+      field: "foo", value: "a!b(c)d{e}f[g]h^i~j:k\\l/m")
     XCTAssertEqual(
       clause.asURLString,
-      "foo:(a\\+b\\-c\\&d\\|e\\!f\\(g\\)h\\{i\\}j\\[k\\]l\\^m\\\"n\\~o\\:p\\\\q\\/r)")
+      "foo:(a\\!b\\(c\\)d\\{e\\}f\\[g\\]h\\^i\\~j\\:k\\\\l\\/m)")
+  }
+
+  /// archive.org's Elasticsearch backend errors on the escaped forms of these
+  /// operator characters (`\-`, `\+`, `\&`, `\|`, `\"`), so they pass through
+  /// unescaped — verified live against advancedsearch.php.
+  func testQueryClauseLeavesElasticsearchOperatorsRaw() {
+    let clause: InternetArchive.QueryClause = InternetArchive.QueryClause(
+      field: "foo", value: "a+b-c&d|e\"f")
+    XCTAssertEqual(clause.asURLString, "foo:(a+b-c&d|e\"f)")
   }
 
   func testQueryClauseKeepsWildcards() {


### PR DESCRIPTION
Fixes #96.

`#70` backslash-escaped the full Lucene special set in non-exactMatch values, but archive.org's Elasticsearch backend errors on the escaped operators (`\-`, `\+`, `\&`, `\|`, `\"`). `-` is in nearly every etree recording identifier, so `identifier:(gd77\-05\-08...)` fails while the unescaped form works.

Drops `+ - & | "` from the escape set (they don't need escaping mid-value on archive.org anyway). Keeps escaping the parser characters `#70` needed (`( ) { } [ ] ^ ~ : \ / !`), which ES accepts escaped.

Verified live against `advancedsearch.php`: `\-` `\+` `\&` `\|` `\"` → `BACKEND_ERROR`; `\[` `\(` `\:` etc → fine; unescaped `-` → works.

All query/escaping tests pass. (The two live-network `scrapeTotal` integration tests fail against archive.org's currently-flaky scrape backend on `main` too — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cf7er8mrabacGCMtLjd6mQ
